### PR TITLE
feature(file-size): Add validation for file size limit based on environment

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -11,12 +11,9 @@
 #' NA
 #' 
 server <- function(input, output, session) {
-  isWebServer <- Sys.getenv("SHINY_ENV") != ""
-  if (isWebServer) {
-    options(shiny.maxRequestSize=10*1024^2) # 10MB
-  } else {
-    options(shiny.maxRequestSize=10000*1024^2) # 10GB
-  }
+  isWebServer <- Sys.getenv("SHINY_ENV", "development") == "production"
+  maxRequestSize <- if (isWebServer) 10*1024^2 else 10000*1024^2
+  options(shiny.maxRequestSize=maxRequestSize)
   session$allowReconnect(TRUE)
   observe({
     toggleClass(condition = TRUE,

--- a/R/server.R
+++ b/R/server.R
@@ -12,8 +12,9 @@
 #' 
 server <- function(input, output, session) {
   isWebServer <- Sys.getenv("SHINY_ENV", "development") == "production"
-  maxRequestSize <- if (isWebServer) 10*1024^2 else 10000*1024^2
-  options(shiny.maxRequestSize=maxRequestSize)
+  if (isWebServer) {
+    options(shiny.maxRequestSize=250*1024^2)
+  }
   session$allowReconnect(TRUE)
   observe({
     toggleClass(condition = TRUE,

--- a/R/server.R
+++ b/R/server.R
@@ -11,7 +11,12 @@
 #' NA
 #' 
 server <- function(input, output, session) {
-  options(shiny.maxRequestSize=10000*1024^2)
+  isWebServer <- Sys.getenv("SHINY_ENV") != ""
+  if (isWebServer) {
+    options(shiny.maxRequestSize=10*1024^2)
+  } else {
+    options(shiny.maxRequestSize=10000*1024^2)
+  }
   session$allowReconnect(TRUE)
   observe({
     toggleClass(condition = TRUE,

--- a/R/server.R
+++ b/R/server.R
@@ -13,9 +13,9 @@
 server <- function(input, output, session) {
   isWebServer <- Sys.getenv("SHINY_ENV") != ""
   if (isWebServer) {
-    options(shiny.maxRequestSize=10*1024^2)
+    options(shiny.maxRequestSize=10*1024^2) # 10MB
   } else {
-    options(shiny.maxRequestSize=10000*1024^2)
+    options(shiny.maxRequestSize=10000*1024^2) # 10GB
   }
   session$allowReconnect(TRUE)
   observe({


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Implemented environment-based validation for file size limits in the Shiny server.
- Set a 250MB file size limit for web server environments and no limit for local environments.
- Enhanced server configuration to dynamically adjust based on the `SHINY_ENV` environment variable.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>server.R</strong><dd><code>Add environment-based file size validation in Shiny server</code></dd></summary>
<hr>

R/server.R

<li>Added environment-based validation for file size limit.<br> <li> Introduced conditional logic to set <code>shiny.maxRequestSize</code>.<br> <li> Differentiated file size limits for web server and local environments.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstatsShiny/pull/98/files#diff-9e95b340633529fb09e594e8e485b849dac8a3aa0d81017be4c7556d34bfb05b">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information