### PR TITLE
feature(network visualization): Redirect users to INDRA when clicking an edge

### DIFF
--- a/R/module-visualize-network-server.R
+++ b/R/module-visualize-network-server.R
@@ -29,7 +29,8 @@ generateCytoscapeJSForShiny <- function(node_elements, edge_elements,
             target: edge.data('target'),
             interaction: edge.data('interaction'),
             edge_type: edge.data('edge_type'),
-            category: edge.data('category')
+            category: edge.data('category'),
+            evidenceLink: edge.data('evidenceLink')
         });
     }"),
     node_click = paste0("function(evt) {
@@ -129,6 +130,17 @@ highlightEdgeInTable <- function(output, edge_data, edges_table) {
                                autoWidth = TRUE), 
                 selection = list(mode = 'single', selected = 1))
     })
+  }
+}
+
+# Open evidence link in new tab
+openEvidenceLink <- function(session, evidence_link) {
+  if (!is.null(evidence_link) && evidence_link != "" && !is.na(evidence_link)) {
+    # Send JavaScript command to open link in new tab
+    session$sendCustomMessage(
+      type = 'openLinkInNewTab',
+      message = list(url = evidence_link)
+    )
   }
 }
 
@@ -494,6 +506,7 @@ visualizeNetworkServer <- function(input, output, session, parent_session, dataC
     edges_table <- network_data$edges_table
     
     highlightEdgeInTable(output, edge_data, edges_table)
+    openEvidenceLink(session, edge_data$evidenceLink)
   })
   
   # Observe node click events

--- a/R/module-visualize-network-server.R
+++ b/R/module-visualize-network-server.R
@@ -135,13 +135,18 @@ highlightEdgeInTable <- function(output, edge_data, edges_table) {
 
 # Open evidence link in new tab
 openEvidenceLink <- function(session, evidence_link) {
-  if (!is.null(evidence_link) && evidence_link != "" && !is.na(evidence_link)) {
-    # Send JavaScript command to open link in new tab
-    session$sendCustomMessage(
+  if (is.null(evidence_link) || is.na(evidence_link)) return(invisible(NULL))
+  link <- trimws(as.character(evidence_link)[1])
+  if (!nzchar(link)) return(invisible(NULL))
+  # Allow only http(s)
+    if (!grepl("^https?://", link, ignore.case = TRUE)) {
+        showNotification("Blocked non-http(s) evidence link.", type = "warning")
+        return(invisible(NULL))
+      }
+  session$sendCustomMessage(
       type = 'openLinkInNewTab',
-      message = list(url = evidence_link)
+      message = list(url = link)
     )
-  }
 }
 
 # =============================================================================

--- a/R/module-visualize-network-ui.R
+++ b/R/module-visualize-network-ui.R
@@ -20,11 +20,12 @@ createCytoscapeScripts <- function() {
     tags$script("
             Shiny.addCustomMessageHandler('openLinkInNewTab', function(message) {
               try {
-                if (message.url) {
-                  if (message.url.trim() !== '') {
-                    window.open(message.url, '_blank');
-                  }
-                }
+                if (!message || typeof message.url !== 'string') return;
+                var url = message.url.trim();
+                if (!url) return;
+                if (!/^https?:\\/\\//i.test(url)) { console.warn('Blocked non-http(s) URL'); return; }
+                var win = window.open(url, '_blank', 'noopener,noreferrer');
+                if (win) { win.opener = null; }
               } catch (err) {
                 console.error('Error opening link:', err);
               }

--- a/R/module-visualize-network-ui.R
+++ b/R/module-visualize-network-ui.R
@@ -16,6 +16,16 @@ createCytoscapeScripts <- function() {
                 console.error('Error running Cytoscape code:', err);
               }
             });
+            
+            Shiny.addCustomMessageHandler('openLinkInNewTab', function(message) {
+              try {
+                if (message.url && message.url.trim() !== '') {
+                  window.open(message.url, '_blank');
+                }
+              } catch (err) {
+                console.error('Error opening link:', err);
+              }
+            });
         ")
   )
 }

--- a/R/module-visualize-network-ui.R
+++ b/R/module-visualize-network-ui.R
@@ -16,11 +16,14 @@ createCytoscapeScripts <- function() {
                 console.error('Error running Cytoscape code:', err);
               }
             });
-            
+        "),
+    tags$script("
             Shiny.addCustomMessageHandler('openLinkInNewTab', function(message) {
               try {
-                if (message.url && message.url.trim() !== '') {
-                  window.open(message.url, '_blank');
+                if (message.url) {
+                  if (message.url.trim() !== '') {
+                    window.open(message.url, '_blank');
+                  }
                 }
               } catch (err) {
                 console.error('Error opening link:', err);


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add edge evidence link propagation

- Open evidence links in new tab

- Handle empty/invalid URLs safely

- Integrate edge click with table highlight


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cytoscape edge click (JS)"] -- "send edge data incl. evidenceLink" --> B["Shiny input edgeClicked"]
  B -- "server observes" --> C["highlightEdgeInTable"]
  B -- "extract evidenceLink" --> D["openEvidenceLink(session, url)"]
  D -- "custom message" --> E["UI handler openLinkInNewTab"]
  E -- "window.open(url, _blank)" --> F["New browser tab"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>module-visualize-network-server.R</strong><dd><code>Add evidence link handling and opening logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/module-visualize-network-server.R

<ul><li>Include <code>evidenceLink</code> in edge click payload.<br> <li> Add <code>openEvidenceLink</code> helper with validation.<br> <li> Trigger link opening on edge click after highlighting.</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstatsShiny/pull/115/files#diff-ce5596fa2500281f5b679d028a3b894edb34f7ee3a1bc9dec5367332a89b9267">+14/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>module-visualize-network-ui.R</strong><dd><code>UI handler to open links in new tab</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

R/module-visualize-network-ui.R

<ul><li>Add custom message handler <code>openLinkInNewTab</code>.<br> <li> Safely open non-empty URLs in a new tab with error logging.</ul>


</details>


  </td>
  <td><a href="https://github.com/Vitek-Lab/MSstatsShiny/pull/115/files#diff-982d8cbbdfb02e3b12cdee1883087d460344225eb1027af62daa5e2f6efc144d">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clicking a network edge now opens its associated evidence link in a new browser tab for quick access to source material.
  * Edge interactions now include an “evidence link” attribute, enabling direct navigation from the visualization.
  * After an edge is highlighted in the edges table, the related evidence page automatically opens to streamline review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->