### PR TITLE
add curation filtering on Shiny for network interpretation

### DIFF
--- a/R/module-visualize-network-server.R
+++ b/R/module-visualize-network-server.R
@@ -242,7 +242,7 @@ getInputParameters <- function(input, selectedProteins) {
   }
   
   filterByCuration <- if(is.null(input$filterByCuration)) {
-    FALSE  # Default to FALSE if somehow NULL
+    FALSE  # Default to FALSE if somehow NULL 
   } else {
     as.logical(input$filterByCuration)
   }

--- a/R/module-visualize-network-server.R
+++ b/R/module-visualize-network-server.R
@@ -293,8 +293,7 @@ extractSubnetwork <- function(annotated_df, pValue, evidence, statementTypes,
                            sources_filter = sources,
                            logfc_cutoff = absLogFC,
                            force_include_other = selectedProteins,
-                           filter_by_curation = filterByCuration,
-                           api_key = "")
+                           filter_by_curation = filterByCuration)
   }, error = function(e) {
     showNotification(paste("Error in subnetwork extraction:", e$message), type = "error")
     print(e$message)

--- a/R/module-visualize-network-server.R
+++ b/R/module-visualize-network-server.R
@@ -241,6 +241,12 @@ getInputParameters <- function(input, selectedProteins) {
     selectedProteins
   }
   
+  filterByCuration <- if(is.null(input$filterByCuration)) {
+    FALSE  # Default to FALSE if somehow NULL
+  } else {
+    as.logical(input$filterByCuration)
+  }
+  
   list(
     proteinIdType = req(input$proteinIdType),
     pValue = as.numeric(req(input$pValue)),
@@ -249,7 +255,8 @@ getInputParameters <- function(input, selectedProteins) {
     statementTypes = statementTypes,
     sources = sources,
     selectedLabel = req(input$selectedLabel),
-    selectedProteins = selectedProteins
+    selectedProteins = selectedProteins,
+    filterByCuration = filterByCuration
   )
 }
 
@@ -277,7 +284,7 @@ annotateProteinData <- function(df, proteinIdType) {
 }
 
 extractSubnetwork <- function(annotated_df, pValue, evidence, statementTypes, 
-                              sources, absLogFC, selectedProteins) {
+                              sources, absLogFC, selectedProteins, filterByCuration) {
   tryCatch({
     getSubnetworkFromIndra(annotated_df, 
                            pvalueCutoff = pValue, 
@@ -285,7 +292,9 @@ extractSubnetwork <- function(annotated_df, pValue, evidence, statementTypes,
                            statement_types = statementTypes,
                            sources_filter = sources,
                            logfc_cutoff = absLogFC,
-                           force_include_other = selectedProteins)
+                           force_include_other = selectedProteins,
+                           filter_by_curation = filterByCuration,
+                           api_key = "")
   }, error = function(e) {
     showNotification(paste("Error in subnetwork extraction:", e$message), type = "error")
     print(e$message)
@@ -521,7 +530,8 @@ visualizeNetworkServer <- function(input, output, session, parent_session, dataC
     
     subnetwork <- extractSubnetwork(annotated_df, params$pValue, params$evidence, 
                                     params$statementTypes, params$sources,
-                                    params$absLogFC, params$selectedProteins)
+                                    params$absLogFC, params$selectedProteins,
+                                    params$filterByCuration)
     if (is.null(subnetwork)) return(NULL)
     
     return(list(
@@ -602,6 +612,8 @@ visualizeNetworkServer <- function(input, output, session, parent_session, dataC
     } else {
       codes <- paste(codes, ",\n  force_include_other = NULL\n", sep = "")
     }
+    
+    codes <- paste(codes, ",\n  filter_by_curation = ", params$filterByCuration, "\n", sep = "")
     
     codes <- paste(codes, ")\n\n", sep = "")
     

--- a/R/module-visualize-network-ui.R
+++ b/R/module-visualize-network-ui.R
@@ -260,7 +260,7 @@ createFilterDropdowns <- function(ns) {
         "Force Include Proteins (optional):",
         class = "icon-wrapper",
         icon("question-circle", lib = "font-awesome"),
-        div("Search for specific proteins to include in the network analysis regardless of other filtering criteria. Type a protein name or gene symbol to search.", 
+        div("Search for specific proteins to include in the network analysis regardless of other filtering criteria. As a hidden feature, you can also search by any biological agent, e.g. drugs, GO terms, etc!", 
             class = "icon-tooltip")
       ),
       # Container for selected proteins

--- a/R/module-visualize-network-ui.R
+++ b/R/module-visualize-network-ui.R
@@ -289,6 +289,21 @@ createFilterDropdowns <- function(ns) {
   )
 }
 
+createCurationFilterCheckbox <- function(ns) {
+  div(
+    tags$label(
+      "Filter Out Incorrect Statements:",
+      class = "icon-wrapper",
+      icon("question-circle", lib = "font-awesome"),
+      div("When checked, excludes protein regulatory relationships that have been manually curated as incorrect in the INDRA database.", 
+          class = "icon-tooltip")
+    ),
+    checkboxInput(ns("filterByCuration"),
+                  label = "Filter out statements curated as incorrect",
+                  value = FALSE)
+  )
+}
+
 createDisplayNetworkButton <- function(ns) {
   tagList(
     actionButton(ns("showNetwork"), 
@@ -321,6 +336,7 @@ createDataUploadBox <- function(ns) {
     createDisplayLabelRadioButtons(ns),
     createParameterSliders(ns),
     createFilterDropdowns(ns),
+    createCurationFilterCheckbox(ns),
     createDisplayNetworkButton(ns)
   )
 }

--- a/tests/testthat/test_network_visualization.R
+++ b/tests/testthat/test_network_visualization.R
@@ -179,7 +179,7 @@ test_that("extractSubnetwork works with mocked MSstatsBioNet function", {
   # Create a mock function that returns the expected subnetwork
   mock_extract_func <- function(df, pvalueCutoff, evidence_count_cutoff, 
                                 statement_types, sources_filter, 
-                                logfc_cutoff, force_include_other) {
+                                logfc_cutoff, force_include_other, filter_by_curation) {
     return(expected_subnetwork)
   }
   

--- a/tests/testthat/test_network_visualization.R
+++ b/tests/testthat/test_network_visualization.R
@@ -193,7 +193,8 @@ test_that("extractSubnetwork works with mocked MSstatsBioNet function", {
     statementTypes = NULL,
     sources = NULL, 
     absLogFC = 0.5, 
-    selectedProteins = NULL
+    selectedProteins = NULL,
+    filterByCuration = FALSE
   )
   
   expect_type(result, "list")
@@ -233,7 +234,7 @@ test_that("Full pipeline works with mocked functions", {
   # Test the full pipeline
   filtered_df <- filterDataByLabel(input_df, "Treatment_vs_Control")
   annotated <- annotateProteinData(filtered_df, "Uniprot")
-  subnet <- extractSubnetwork(annotated, 0.05, 5, NULL, NULL, 0.5, NULL)
+  subnet <- extractSubnetwork(annotated, 0.05, 5, NULL, NULL, 0.5, NULL, FALSE)
   
   # Generate configuration
   js_code <- generateCytoscapeJSForShiny(subnet$nodes, subnet$edges)
@@ -265,7 +266,7 @@ test_that("Functions handle errors gracefully", {
   # Test extractSubnetwork with error
   stub(extractSubnetwork, "getSubnetworkFromIndra", mock_error_func)
   stub(extractSubnetwork, "showNotification", mock_show_notification)
-  result2 <- extractSubnetwork(create_mock_annotated_data(), 0.05, 5, NULL, NULL, 0.5, NULL)
+  result2 <- extractSubnetwork(create_mock_annotated_data(), 0.05, 5, NULL, NULL, 0.5, NULL, FALSE)
   expect_null(result2)
 })
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Motivation and context
- Motivation: Give users an option in the Shiny network module to exclude INDRA statements that have been curated as incorrect, and remove an explicit external API key dependency from the Shiny code path while keeping behavior stable by default.
- High-level solution: Add a UI checkbox to toggle curation-based filtering, thread a new boolean parameter filterByCuration through input parsing, subnetwork extraction, and code-generation so INDRA subnetwork calls include filter_by_curation; default the flag to FALSE when unspecified. Update tests and mocks to match the extended signatures.

Detailed changes
- UI
  - Added createCurationFilterCheckbox(ns): renders a labeled checkbox "Filter out statements curated as incorrect" with a supporting tooltip.
  - Integrated the new checkbox into the Data Upload / filter area of the visualize network UI.
  - Expanded tooltip for "Force Include Proteins" to mention hidden searches by additional biological agents (e.g., drugs, GO terms).
- Server / input handling
  - getInputParameters now reads filterByCuration and normalizes NULL to FALSE so downstream callers always receive a boolean.
  - Added filterByCuration parameter to extractSubnetwork(…); it is forwarded to getSubnetworkFromIndra as filter_by_curation.
  - visualizeNetworkServer updated to pass filterByCuration into extractSubnetwork.
  - generate_network_code / code-generation path now includes filter_by_curation = filterByCuration when constructing INDRA subnetwork calls.
  - API key: Shiny-side subnetwork call path no longer supplies an explicit api_key parameter (api_key left as default / removed from Shiny invocation).
- Exports / signatures
  - New exported/public function: createCurationFilterCheckbox(ns).
  - extractSubnetwork(...) signature extended to accept filterByCuration as the final parameter and propagate it through the call chain.

Unit tests added or modified
- tests/testthat/test_network_visualization.R updated:
  - Mock for getSubnetworkFromIndra (used by tests) extended to accept filter_by_curation so the stub matches the new call signature.
  - Calls to extractSubnetwork in tests updated to include filterByCuration (passed as FALSE where appropriate).
  - Test expectations for returned subnetwork (node/edge counts and shapes) remain unchanged; tests verify behavior with the new parameter present.

Coding guidelines / potential issues
- Public API & NAMESPACE: A new exported UI helper (createCurationFilterCheckbox) was added — ensure it is documented and exported in NAMESPACE so package checks recognize it as intended public API.
- Backwards compatibility: extractSubnetwork signature changed (added parameter). Call sites in package code and external users should receive boolean by default (NULL -> FALSE), but consumers calling extractSubnetwork directly may need to adapt if they relied on the previous signature.
- No other obvious style or guideline violations identified in the changed files reviewed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->