### PR TITLE
Feature: Use shinyFiles for local file uploads

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Authors@R: c(
     person("Olga", "Vitek", email = "o.vitek@northeastern.edu", role = "aut"))
 License: Artistic-2.0
 Depends: R (>= 4.2)
-Imports: shiny, shinyBS, shinyjs, shinybusy, dplyr, ggplot2, plotly, data.table, Hmisc,
+Imports: shiny, shinyBS, shinyjs, shinybusy, shinyFiles, dplyr, ggplot2, plotly, data.table, Hmisc,
   MSstats, MSstatsTMT, MSstatsPTM, MSstatsConvert, gplots, marray, DT, readxl,
   ggrepel, uuid, utils, stats, htmltools, methods, tidyr, grDevices, graphics, mockery, MSstatsBioNet,
   shinydashboard, arrow, tools

--- a/R/module-loadpage-server.R
+++ b/R/module-loadpage-server.R
@@ -12,7 +12,7 @@
 #' @examples
 #' NA
 #' 
-loadpageServer <- function(id, parent_session, is_web_servee) {
+loadpageServer <- function(id, parent_session, is_web_server) {
   moduleServer(id, function(input, output, session) {
     # toggle ui (DDA DIA SRM)
     observe({

--- a/R/module-loadpage-server.R
+++ b/R/module-loadpage-server.R
@@ -12,7 +12,7 @@
 #' @examples
 #' NA
 #' 
-loadpageServer <- function(id, parent_session, is_web_server) {
+loadpageServer <- function(id, parent_session, is_web_servee) {
   moduleServer(id, function(input, output, session) {
     # toggle ui (DDA DIA SRM)
     observe({

--- a/R/module-loadpage-server.R
+++ b/R/module-loadpage-server.R
@@ -12,7 +12,7 @@
 #' @examples
 #' NA
 #' 
-loadpageServer <- function(id, parent_session) {
+loadpageServer <- function(id, parent_session, is_web_server) {
   moduleServer(id, function(input, output, session) {
     # toggle ui (DDA DIA SRM)
     observe({

--- a/R/module-loadpage-server.R
+++ b/R/module-loadpage-server.R
@@ -12,7 +12,7 @@
 #' @examples
 #' NA
 #' 
-loadpageServer <- function(id, parent_session, is_web_server) {
+loadpageServer <- function(id, parent_session, is_web_serveR) {
   moduleServer(id, function(input, output, session) {
     # toggle ui (DDA DIA SRM)
     observe({

--- a/R/module-loadpage-server.R
+++ b/R/module-loadpage-server.R
@@ -12,7 +12,7 @@
 #' @examples
 #' NA
 #' 
-loadpageServer <- function(id, parent_session, is_web_server) {
+loadpageServer <- function(id, parent_session, is_web_server = FALSE) {
   moduleServer(id, function(input, output, session) {
     # toggle ui (DDA DIA SRM)
     observe({

--- a/R/module-loadpage-server.R
+++ b/R/module-loadpage-server.R
@@ -12,9 +12,49 @@
 #' @examples
 #' NA
 #' 
-loadpageServer <- function(id, parent_session, is_web_server = FALSE) {
+loadpageServer <- function(id, parent_session, is_web_server = TRUE) {
   moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+    
+    # Conditionally render the file input UI
+    output$diann_upload_ui <- renderUI({
+      if (is_web_server) {
+        # For web server, use the standard fileInput
+        fileInput(ns('dianndata'), "", multiple = FALSE, accept = NULL)
+      } else {
+        # For local instances, use shinyFiles for direct path access
+        shinyFiles::shinyFilesButton(ns('dianndata_sf'), 
+                                     label='Browse for DIANN report', 
+                                     title='Please select a DIANN report file', 
+                                     multiple=FALSE)
+      }
+    })
+    
+    # Display the name of the selected file for user feedback
+    output$diann_file_name_display <- renderText({
+      if (is_web_server) {
+        # For the web server, the file name is in the standard fileInput object
+        req(input$dianndata)
+        return(input$dianndata$name)
+      } else {
+        # For local instances, we parse the path from the shinyFiles object
+        req(is.list(input$dianndata_sf) && length(input$dianndata_sf) > 1)
+        volumes <- shinyFiles::getVolumes()()
+        parsed_path <- shinyFiles::parseFilePaths(volumes, input$dianndata_sf)
+        # Return the 'name' column from the parsed data frame
+        return(as.character(parsed_path$name))
+      }
+    })
+    
     # toggle ui (DDA DIA SRM)
+    # Set up the shinyFiles server logic, but only for local instances.
+    if (!is_web_server) {
+      # getVolumes returns a function, so we need the extra () to execute it.
+      # This gets the user's local drives (C:/, /Users, etc.)
+      volumes <- shinyFiles::getVolumes()()
+      # This connects the server logic to the 'dianndata_sf' button in the UI.
+      shinyFiles::shinyFileChoose(input, "dianndata_sf", roots = volumes, session = session)
+    }
     observe({
       print("bio")
       
@@ -111,7 +151,15 @@ loadpageServer <- function(id, parent_session, is_web_server = FALSE) {
                 enable("proceed1")
               }
             } else if (input$filetype == "diann") {
-              if(!is.null(input$dianndata) && !is.null(input$sep_dianndata)) { # && !is.null(input$annot)
+              # Check for file readiness from either input type
+              file_ready <- if (is_web_server) {
+                !is.null(input$dianndata)
+              } else {
+                is.list(input$dianndata_sf) && length(input$dianndata_sf) > 1
+              }
+              
+              # Enable the button if a file is ready and a separator has been selected.
+              if(file_ready && !is.null(input$sep_dianndata)) {
                 enable("proceed1")
               }
             }
@@ -221,7 +269,18 @@ loadpageServer <- function(id, parent_session, is_web_server = FALSE) {
 
 
     get_data = eventReactive(input$proceed1, {
-      getData(input)
+      # Create a modifiable copy of the reactive 'input' object.
+      local_input <- reactiveValuesToList(input)
+      
+      # For local DIANN, parse the shinyFiles path before calling getData
+      if (isTRUE(input$filetype == "diann") && !is_web_server) {
+        volumes <- shinyFiles::getVolumes()()
+        parsed_path <- shinyFiles::parseFilePaths(volumes, input$dianndata_sf)
+        # Modify our local copy to mimic the structure of a fileInput object.
+        local_input$dianndata <- list(datapath = parsed_path$datapath)
+      }
+      
+      getData(local_input)
     })
 
 

--- a/R/module-loadpage-server.R
+++ b/R/module-loadpage-server.R
@@ -12,7 +12,7 @@
 #' @examples
 #' NA
 #' 
-loadpageServer <- function(id, parent_session, is_web_serveR) {
+loadpageServer <- function(id, parent_session, is_web_server) {
   moduleServer(id, function(input, output, session) {
     # toggle ui (DDA DIA SRM)
     observe({

--- a/R/module-loadpage-ui.R
+++ b/R/module-loadpage-ui.R
@@ -274,10 +274,14 @@ create_diann_uploads <- function(ns) {
   conditionalPanel(
     condition = "input['loadpage-filetype'] == 'diann' && input['loadpage-BIO'] != 'PTM'",
     h4("4. Upload MSstats report from DIANN"),
-    fileInput(ns('dianndata'), "", multiple = FALSE, accept = NULL),
+    #Dynamic File Input UI for DIANN files
+    uiOutput(ns("diann_upload_ui")),
+    #placeholder to display the name of the selected file
+    verbatimTextOutput(ns("diann_file_name_display")),
     create_separator_buttons(ns, "sep_dianndata")
   )
 }
+
 
 #' Create Spectronaut file uploads
 #' @noRd

--- a/R/server.R
+++ b/R/server.R
@@ -32,7 +32,7 @@ server = function(input, output, session) {
                       selected = "Uploaddata")
   })
   
-  loadpage_values = loadpageServer("loadpage", parent_session = session)
+  loadpage_values = loadpageServer("loadpage", parent_session = session, is_web_server = isWebServer)
   loadpage_input = loadpage_values$input
   get_data = loadpage_values$getData
   


### PR DESCRIPTION
This pull request changes how file uploads work for users running the app locally. It uses the shinyFiles package to get a direct path to user files, which avoids copying large files into a temporary directory. This makes uploads faster for local users.

### Main changes:
Added shinyFiles to the DESCRIPTION file.
The DIANN upload UI now shows a shinyFilesButton for local users and the standard fileInput for web users.
A text output was added to show the name of the selected file.

These changes only affect users running the app locally and do not change the behavior for the web server.


### Remaining Tasks:
Create tests for the new conditional UI and server logic.
Create documentation and update release notes for this new feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced DIANN file upload interface with adaptive UI for web and local deployment modes
  * Added local file browsing capability for non-web instances
  * Improved file selection feedback with file name display
  
* **Dependencies**
  * Added shinyFiles package to package imports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->