### PR TITLE
fix(skyline-converter): Enable q-value filtering from the user

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -424,8 +424,8 @@ getData <- function(input) {
       # }
         mydata = SkylinetoMSstatsFormat(data,
                                         annotation = getAnnot(input),
-                                        filter_with_Qvalue = TRUE,
-                                        qvalue_cutoff = 0.01,
+                                        filter_with_Qvalue = input$q_val, 
+                                        qvalue_cutoff = input$q_cutoff,
                                         fewMeasurements="remove",
                                         removeProtein_with1Feature = TRUE,
                                         use_log_file = FALSE)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Q-value filtering settings are now customizable through user inputs, allowing adjustment of data processing parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->