### PR TITLE
Adding anomaly metric g UI

### DIFF
--- a/R/module-loadpage-ui.R
+++ b/R/module-loadpage-ui.R
@@ -536,9 +536,16 @@ create_quality_filtering_options <- function(ns) {
     conditionalPanel(
       condition = "input['loadpage-filetype'] == 'spec'",
       checkboxInput(ns("calculate_anomaly_scores"), 
-                    label = h5("Calculate Anomaly Scores", class = "icon-wrapper",
-                               icon("question-circle", lib = "font-awesome"),
-                               div("Calculate anomaly scores for each feature based on a random forest model. This requires a run order file.", class = "icon-tooltip")), value = FALSE),
+                    label = tags$span(
+                      "Calculate Anomaly Scores",
+                      tags$span(
+                        class = "icon-wrapper",
+                        icon("question-circle", lib = "font-awesome"),
+                        div("Calculate anomaly scores for each feature based on a random forest model. This requires a CSV file containing the order of your MS runs.", 
+                            class = "icon-tooltip")
+                      )
+                    ), 
+                    value = FALSE),
       conditionalPanel(
         condition = "input['loadpage-calculate_anomaly_scores']",
         fileInput(ns("run_order_file"), 

--- a/R/module-loadpage-ui.R
+++ b/R/module-loadpage-ui.R
@@ -538,12 +538,10 @@ create_quality_filtering_options <- function(ns) {
       checkboxInput(ns("calculate_anomaly_scores"), 
                     label = tags$span(
                       "Calculate Anomaly Scores",
-                      tags$span(
-                        class = "icon-wrapper",
-                        icon("question-circle", lib = "font-awesome"),
-                        div("Calculate anomaly scores for each feature based on a random forest model. This requires a CSV file containing the order of your MS runs.", 
-                            class = "icon-tooltip")
-                      )
+                      class = "icon-wrapper",
+                      icon("question-circle", lib = "font-awesome"),
+                      div("Calculate anomaly scores for each feature based on a random forest model. This requires a CSV file containing the order of your MS runs.", 
+                          class = "icon-tooltip")
                     ), 
                     value = FALSE),
       conditionalPanel(

--- a/R/module-loadpage-ui.R
+++ b/R/module-loadpage-ui.R
@@ -534,6 +534,22 @@ create_quality_filtering_options <- function(ns) {
     ),
     
     conditionalPanel(
+      condition = "input['loadpage-filetype'] == 'spec'",
+      checkboxInput(ns("calculate_anomaly_scores"), 
+                    label = h5("Calculate Anomaly Scores", class = "icon-wrapper",
+                               icon("question-circle", lib = "font-awesome"),
+                               div("Calculate anomaly scores for each feature based on a random forest model. This requires a run order file.", class = "icon-tooltip")), value = FALSE),
+      conditionalPanel(
+        condition = "input['loadpage-calculate_anomaly_scores']",
+        fileInput(ns("run_order_file"), 
+                  label = h5("Upload Run Order File", class = "icon-wrapper",
+                             icon("question-circle", lib = "font-awesome"),
+                             div("The run order file should be a CSV with two columns: 'Run' and 'Order'. 'Run' contains the sequence name, and 'Order' contains the chronological run number (e.g., 1, 2, 3...).", class = "icon-tooltip")),
+                  multiple = FALSE, accept = c(".csv"))
+      )
+    ),
+    
+    conditionalPanel(
       condition = "input['loadpage-filetype'] == 'open'",
       checkboxInput(ns("m_score"), "Filter with M-score"),
       conditionalPanel(
@@ -543,6 +559,7 @@ create_quality_filtering_options <- function(ns) {
     )
   )
 }
+
 
 #' Create column separator radio buttons
 #' 

--- a/R/utils.R
+++ b/R/utils.R
@@ -500,19 +500,35 @@ getData <- function(input) {
 
     }
     else if(input$filetype == 'spec') {
-
+      
       # if (input$subset){
       #   data = read.csv.sql(infile$datapath, sep="\t",
       #                       sql = "select * from file order by random() limit 100000")
       # } else {
-      data = read.csv(input$specdata$datapath, sep=input$sep_specdata)
+      data = read.csv(input$specdata$datapath, sep=input$sep_specdata, check.names = FALSE)
       # }
-      mydata = SpectronauttoMSstatsFormat(data,
-                                          annotation = getAnnot(input),
-                                          filter_with_Qvalue = TRUE, ## same as default
-                                          qvalue_cutoff = 0.01, ## same as default
-                                          removeProtein_with1Feature = TRUE,
-                                          use_log_file = FALSE)
+      # Base arguments for the Spectronaut converter
+      converter_args = list(
+        input = data,
+        annotation = getAnnot(input),
+        filter_with_Qvalue = input$q_val,
+        qvalue_cutoff = input$q_cutoff,
+        removeProtein_with1Feature = input$remove,
+        use_log_file = FALSE
+      )
+      
+      browser()
+      if (isTRUE(input$calculate_anomaly_scores) && !is.null(input$run_order_file)) {
+        # Add anomaly score parameters only if the checkbox is checked
+        converter_args$calculateAnomalyScores = TRUE
+        converter_args$runOrder = read.csv(input$run_order_file$datapath)
+        converter_args$anomalyModelFeatures = c("FG.ShapeQualityScore (MS2)", "FG.ShapeQualityScore (MS1)", "EGDeltaRT")
+        converter_args$anomalyModelFeatureTemporal = c("mean_decrease", "mean_decrease", "dispersion_increase")
+        converter_args$n_trees = 100
+        converter_args$max_depth = "auto"
+        converter_args$numberOfCores = 1
+      }
+      mydata = do.call(SpectronauttoMSstatsFormat, converter_args)
     }
     else if(input$filetype == 'diann') {
       if (getFileExtension(input$dianndata$name) %in% c("parquet", "pq")) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -517,7 +517,6 @@ getData <- function(input) {
         use_log_file = FALSE
       )
       
-      browser()
       if (isTRUE(input$calculate_anomaly_scores) && !is.null(input$run_order_file)) {
         # Add anomaly score parameters only if the checkbox is checked
         converter_args$calculateAnomalyScores = TRUE

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -573,7 +573,8 @@ test_that("dia spectronaut", {
     mock_input$BIO <- "Protein"
     mock_input$DDA_DIA <- "LType"
     mock_input$filetype = "spec"
-    
+    mock_input$q_val = TRUE 
+    mock_input$q_cutoff = 0.01 
     stub(getData,"getAnnot",NULL)
     
     stub(getData,"read.csv",data.table::fread(system.file("tinytest/raw_data/Spectronaut/spectronaut_input.csv",
@@ -1344,5 +1345,90 @@ test_that("dataComparison statmodel Other", {
     expected_names <- c("ComparisonResult","ModelQC","FittedModel")
     expect_type(output,"list")
     expect_identical(names(output), expected_names)
+  })
+})
+
+
+################################################################################
+#  getData for Spectronaut FUNCTION TESTING
+################################################################################
+
+describe("getData for Spectronaut input with anomaly scores", {
+  
+  # Dummy data frames
+  dummy_spec_data <- data.frame(FG.Charge = 2, PG.ProteinGroups = "Protein1")
+  dummy_run_order <- data.frame(Run = "Run1", Order = 1)
+  dummy_annot <- data.frame(Run = "Run1", Condition = "A")
+  
+  # A mock converter function
+  mock_spectro_converter <- function(...) {
+    args <- list(...)
+    return(args) # Return the arguments for inspection
+  }
+  
+  test_that("adds anomaly score arguments when checkbox is checked", {
+    
+    #SETUP: Mock Shiny input for the "checked" scenario
+    mock_input_anomaly <- list(
+      BIO = "Protein",
+      DDA_DIA = "DIA",
+      filetype = "spec",
+      specdata = list(datapath = "dummy_spec.csv"),
+      sep_specdata = ",",
+      annot = list(datapath = "dummy_annot.csv"),
+      q_val = TRUE,
+      q_cutoff = 0.01,
+      remove = TRUE,
+      calculate_anomaly_scores = TRUE,
+      run_order_file = list(datapath = "dummy_run_order.csv")
+    )
+    
+    # Mock the functions that getData calls
+    stub(getData, "read.csv", function(path, ...) {
+      if (path == "dummy_run_order.csv") return(dummy_run_order)
+      return(dummy_spec_data)
+    })
+    stub(getData, "getAnnot", dummy_annot)
+    
+    stub(getData, "SpectronauttoMSstatsFormat", mock_spectro_converter)
+    
+    #EXECUTION: function call
+    result_args <- getData(mock_input_anomaly)
+    
+    #ASSERTION: Check if the arguments are correct
+    expect_true(result_args$calculateAnomalyScores)
+    expect_equal(result_args$runOrder, dummy_run_order)
+    expect_equal(result_args$anomalyModelFeatures, c("FG.ShapeQualityScore (MS2)", "FG.ShapeQualityScore (MS1)", "EGDeltaRT"))
+    expect_equal(result_args$n_trees, 100)
+  })
+  
+  test_that("does NOT add anomaly score arguments when checkbox is unchecked", {
+    
+    #SETUP: Mock Shiny input for the "unchecked" scenario
+    mock_input_no_anomaly <- list(
+      BIO = "Protein",
+      DDA_DIA = "DIA",
+      filetype = "spec",
+      specdata = list(datapath = "dummy_spec.csv"),
+      sep_specdata = ",",
+      annot = list(datapath = "dummy_annot.csv"),
+      q_val = TRUE,
+      q_cutoff = 0.01,
+      remove = TRUE,
+      calculate_anomaly_scores = FALSE, # Main difference
+      run_order_file = NULL
+    )
+    
+    stub(getData, "read.csv", dummy_spec_data)
+    stub(getData, "getAnnot", dummy_annot)
+    stub(getData, "SpectronauttoMSstatsFormat", mock_spectro_converter)
+    
+    #EXECUTION
+    result_args <- getData(mock_input_no_anomaly)
+    
+    #ASSERTION: Check that the anomaly arguments are NOT present
+    expect_null(result_args$calculateAnomalyScores)
+    expect_null(result_args$runOrder)
+    expect_null(result_args$anomalyModelFeatures)
   })
 })


### PR DESCRIPTION
Added a new checkbox in the MSstatsShiny data upload page to use anomaly metrics. When that checkbox is clicked, added a new upload button to add a Run order file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to calculate anomaly scores when processing Spectral files, with a Run Order CSV upload shown when enabled.
  * Reusable separator-selection control added to improve file-import flexibility across upload sections.

* **Tests**
  * Added tests covering anomaly-score enabled and disabled scenarios for Spectral-file processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->