### PR TITLE
Bug fix sumarization plot

### DIFF
--- a/R/main_calculations.R
+++ b/R/main_calculations.R
@@ -56,46 +56,54 @@ lf_summarization_loop = function(data, qc_input,loadpage_input, busy_indicator =
   peptides_dict = makePeptidesDictionary(as.data.table(unclass(data)), 
                                          toupper(qc_input$norm))
   prep_input = MSstatsPrepareForDataProcess(data, as.numeric(qc_input$log), NULL)
-  prep_input = MSstatsNormalize(prep_input, qc_input$norm, peptides_dict, qc_input$names)
-  prep_input = MSstatsMergeFractions(prep_input)
-  prep_input = MSstatsHandleMissing(prep_input, "TMP", qc_input$MBi,
-                                    "NA", QC_check(qc_input,loadpage_input))
-  prep_input = MSstatsSelectFeatures(prep_input, qc_input$features_used, qc_input$n_feat, 2)
-  processed = getProcessed(prep_input)
-  prep_input = MSstatsPrepareForSummarization(prep_input, "TMP", qc_input$MBi, 
-                                              qc_input$censInt, rm_feat)
+  prep_input = MSstatsNormalize(prep_input, qc_input$norm, peptides_dict, 
+                                qc_input$names)
+  prep_input = MSstatsMergeFractions(prep_input) 
+  prep_input = MSstatsHandleMissing(prep_input, qc_input$summaryMethod, 
+                                    qc_input$MBi, "NA", 
+                                    QC_check(qc_input,loadpage_input))
+  prep_input = MSstatsSelectFeatures(prep_input, qc_input$features_used, 
+                                     qc_input$n_feat, 2)
+  processed = getProcessed(prep_input) 
+  prep_input = MSstatsPrepareForSummarization(prep_input, qc_input$summaryMethod, 
+                                              qc_input$MBi, qc_input$censInt, 
+                                              rm_feat)
   
-  input_split = split(prep_input, prep_input$PROTEIN)
-  
-  num_proteins = length(input_split)
-  
-  if (busy_indicator){
-    ## Setup progress bar stepping
-    update_val = 1/num_proteins
-    counter = 0
+  # Select the summarization function based on the user's choice.
+  if (qc_input$summaryMethod == "linear") {
+    summarize_function <- MSstatsSummarizeSingleLinear
+  } else {
+    summarize_function <- MSstatsSummarizeSingleTMP
   }
   
-  summarized_results = vector("list", num_proteins)
-
-  ## Loop over proteins
-  for (i in seq_len(num_proteins)){
-
-    temp_data = input_split[[i]]
-    summarized_results[[i]] = MSstatsSummarizeSingleTMP(temp_data,
-                                                        qc_input$MBi, qc_input$censInt, 
-                                                        qc_input$remove50)
+  input_split <- split(prep_input, prep_input$PROTEIN)
+  num_proteins <- length(input_split)
+  
+  if (busy_indicator) {
+    # Setup progress bar stepping
+    update_val <- 1 / num_proteins
+    counter <- 0
+  }
+  
+  summarized_results <- vector("list", num_proteins)
+  
+  # Loop over all proteins and apply the selected summarization function
+  for (i in seq_len(num_proteins)) {
+    temp_data <- input_split[[i]]
+    summarized_results[[i]] <- summarize_function(temp_data, qc_input$MBi, 
+                                                  qc_input$censInt, qc_input$remove50)
     
-    ## Update progress bar
-    if (busy_indicator){
-      counter = counter + update_val
+    # Update progress bar
+    if (busy_indicator) {
+      counter <- counter + update_val
       update_modal_progress(counter)
     }
   }
   
-  ## Summarization output
-  preprocessed = MSstatsSummarizationOutput(prep_input, summarized_results, 
-                                             processed, "TMP", qc_input$MBi, 
-                                            qc_input$censInt)
+  # Format the final output
+  preprocessed <- MSstatsSummarizationOutput(prep_input, summarized_results, processed, 
+                                             qc_input$summaryMethod, qc_input$MBi, 
+                                             qc_input$censInt)
   
   if (busy_indicator){
     remove_modal_progress() # remove it when done

--- a/R/module-qc-server.R
+++ b/R/module-qc-server.R
@@ -131,6 +131,30 @@ qcServer <- function(input, output, session,parent_session, loadpage_input,get_d
     }
   })
   
+  output$summaryMethodUI <- renderUI({
+    ns <- session$ns
+    
+    # Default choices
+    choices <- c("TMP" = "TMP")
+    
+    # Conditionally add MSstats+ if anomaly score calculation is checked
+    if (isTRUE(loadpage_input()$calculate_anomaly_scores)) {
+      choices <- c(choices, "MSstats+" = "linear")
+    }
+    
+    radioButtons(
+      ns("summaryMethod"),
+      label = h4(
+        "6. Summarization",
+        class = "icon-wrapper",
+        icon("question-circle", lib = "font-awesome"),
+        div("Run-level summarization method. TMP is Tukey's Median Polish. MSstats+ is a linear mixed model.", class = "icon-tooltip")
+      ),
+      choices = choices,
+      selected = "TMP"
+    )
+  })
+  
   # preprocess data
   preprocess_data = eventReactive(input$run, {
     

--- a/R/module-qc-server.R
+++ b/R/module-qc-server.R
@@ -114,7 +114,7 @@ qcServer <- function(input, output, session,parent_session, loadpage_input,get_d
       # } else {
       selectizeInput(ns("which"), "Show plot for", 
                      choices = c("", "ALL PROTEINS" = "allonly", 
-                                 unique(get_data()[1])))
+                                 unique(get_data()$ProteinName)))
       # }
     } else if (loadpage_input()$BIO == "PTM"){
       if (input$type1 == "QCPlot"){
@@ -127,7 +127,7 @@ qcServer <- function(input, output, session,parent_session, loadpage_input,get_d
       }
     } else {
       selectizeInput(ns("which"), "Show plot for", 
-                     choices = c("", unique(get_data()[1])))
+                     choices = c("", unique(get_data()$ProteinName)))
     }
   })
   

--- a/R/module-qc-ui.R
+++ b/R/module-qc-ui.R
@@ -167,10 +167,7 @@ qcUI <- function(id) {
           tags$style(HTML('#qc-run{background-color:orange}')),
           ### summary method
           
-          h4("6. Summarization",class = "icon-wrapper",icon("question-circle", lib = "font-awesome"),
-             div("Run-level summarization method", class = "icon-tooltip")),
-          p("method: TMP"),
-          p("For linear summarzation please use command line"),
+          uiOutput(ns("summaryMethodUI")),
           tags$hr(),
           
           # remove features with more than 50% missing 

--- a/tests/testthat/test-main_calculations.R
+++ b/tests/testthat/test-main_calculations.R
@@ -1,0 +1,53 @@
+library(testthat)
+library(mockery)
+
+test_that("lf_summarization_loop calls the correct summarizer for 'linear' method", {
+  # 1. Create mock objects for the summarization functions
+  mock_linear <- mock()
+  mock_tmp <- mock()
+  
+  # 2. Stub all the heavy preprocessing functions to return simple data frames
+  #    and the summarization functions to use our mocks.
+  stub(lf_summarization_loop, "makePeptidesDictionary", list())
+  stub(lf_summarization_loop, "MSstatsPrepareForDataProcess", data.frame(PROTEIN = "p1"))
+  stub(lf_summarization_loop, "MSstatsNormalize", data.frame(PROTEIN = "p1"))
+  stub(lf_summarization_loop, "MSstatsMergeFractions", data.frame(PROTEIN = "p1"))
+  stub(lf_summarization_loop, "MSstatsHandleMissing", data.frame(PROTEIN = "p1"))
+  stub(lf_summarization_loop, "MSstatsSelectFeatures", data.frame(PROTEIN = "p1"))
+  stub(lf_summarization_loop, "getProcessed", data.frame(PROTEIN = "p1"))
+  stub(lf_summarization_loop, "MSstatsPrepareForSummarization", data.frame(PROTEIN = "p1"))
+  stub(lf_summarization_loop, "MSstatsSummarizationOutput", "done")
+  stub(lf_summarization_loop, "MSstatsSummarizeSingleLinear", mock_linear)
+  stub(lf_summarization_loop, "MSstatsSummarizeSingleTMP", mock_tmp)
+  
+  # 3. Run the function with minimal input
+  qc_input <- list(summaryMethod = "linear", features_used = "all", MBi = TRUE, censInt = "NA", remove50 = FALSE)
+  lf_summarization_loop(data.frame(), qc_input, list(), busy_indicator = FALSE)
+  
+  # 4. Assert that the correct function was called and the other was not.
+  expect_called(mock_linear, 1)
+  expect_called(mock_tmp, 0)
+})
+
+test_that("lf_summarization_loop calls the correct summarizer for 'TMP' method", {
+  mock_linear <- mock()
+  mock_tmp <- mock()
+  
+  stub(lf_summarization_loop, "makePeptidesDictionary", list())
+  stub(lf_summarization_loop, "MSstatsPrepareForDataProcess", data.frame(PROTEIN = "p1"))
+  stub(lf_summarization_loop, "MSstatsNormalize", data.frame(PROTEIN = "p1"))
+  stub(lf_summarization_loop, "MSstatsMergeFractions", data.frame(PROTEIN = "p1"))
+  stub(lf_summarization_loop, "MSstatsHandleMissing", data.frame(PROTEIN = "p1"))
+  stub(lf_summarization_loop, "MSstatsSelectFeatures", data.frame(PROTEIN = "p1"))
+  stub(lf_summarization_loop, "getProcessed", data.frame(PROTEIN = "p1"))
+  stub(lf_summarization_loop, "MSstatsPrepareForSummarization", data.frame(PROTEIN = "p1"))
+  stub(lf_summarization_loop, "MSstatsSummarizationOutput", "done")
+  stub(lf_summarization_loop, "MSstatsSummarizeSingleLinear", mock_linear)
+  stub(lf_summarization_loop, "MSstatsSummarizeSingleTMP", mock_tmp)
+  
+  qc_input <- list(summaryMethod = "TMP", features_used = "all", MBi = TRUE, censInt = "NA", remove50 = FALSE)
+  lf_summarization_loop(data.frame(), qc_input, list(), busy_indicator = FALSE)
+  
+  expect_called(mock_tmp, 1)
+  expect_called(mock_linear, 0)
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -992,6 +992,7 @@ test_that("preprocessData QC, PTM and PTMTMT: No", {
     mock_input$filetype = "sample"
     mock_input$norm = "equalizeMedians"
     mock_input$log = "2"
+    mock_input$summaryMethod = "linear"
 
     stub(preprocessData,"getData",mockGetData(mock_input))
     stub(preprocessData,"loadpage_input",mock_input)
@@ -1022,6 +1023,7 @@ test_that("preprocessData QC, PTM and PTMTMT: Yes", {
     mock_input$norm = "equalizeMedians"
     mock_input$log = "2"
     mock_input$summarization = "msstats"
+    mock_input$summaryMethod = "linear"
 
     stub(preprocessData,"getData",mockGetData(mock_input))
     stub(preprocessData,"loadpage_input",mock_input)
@@ -1082,6 +1084,7 @@ test_that("preprocessData QC Other", {
     mock_input$filetype = "sample"
     mock_input$norm = "equalizeMedians"
     mock_input$log = "2"
+    mock_input$summaryMethod = "linear"
 
     stub(preprocessData,"getData",mockGetData(mock_input))
     stub(preprocessData,"loadpage_input",mock_input)
@@ -1215,6 +1218,7 @@ test_that("dataComparison statmodel PTM PTMTMT: No", {
     mock_input$MBi = TRUE
     mock_input$log = "2"
     mock_input$norm = "equalizeMedians"
+    mock_input$summaryMethod = "linear"
 
     stub(dataComparison,"loadpage_input",mock_input,2)
     stub(dataComparison,"qc_input",mock_input)
@@ -1318,6 +1322,7 @@ test_that("dataComparison statmodel Other", {
     mock_input$filetype = "sample"
     mock_input$norm = "equalizeMedians"
     mock_input$log = "2"
+    mock_input$summaryMethod = "linear"
 
     stub(dataComparison,"loadpage_input",mock_input,2)
     stub(dataComparison,"qc_input",mock_input)


### PR DESCRIPTION
Fix: Replace index-based column lookup with name-based lookup

Processing the run order file reorders the in-memory data, shifting the 'ProteinName' column. The dropdown logic relied on a fixed index, leading to data mismatches.

Updated the code to target the column by name ('ProteinName') to ensure stability regardless of column order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new summarization method selector, allowing users to choose between TMP or MSstats+ (linear) for Run-level summarization. The MSstats+ option is available when anomaly score calculation is enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->