### PR TITLE
fix(msstats+): Fix lookup of protein IDs for profile plots

### DIFF
--- a/R/main_calculations.R
+++ b/R/main_calculations.R
@@ -161,6 +161,7 @@ lf_summarization_loop = function(data, qc_input,loadpage_input, busy_indicator =
 #' qc_input$reference_norm = TRUE
 #' qc_input$remove_norm_channel = TRUE
 #' qc_input$maxQC1 = NULL
+#' qc_input$summaryMethod = "TMP"
 #' summarization_tmt_test = tmt_summarization_loop(testdata, qc_input,loadpage_input, 
 #'                                                busy_indicator = FALSE)
 #' 

--- a/R/main_calculations.R
+++ b/R/main_calculations.R
@@ -37,6 +37,7 @@
 #' qc_input$maxQC = 0.999
 #' qc_input$null = FALSE
 #' qc_input$null1 = FALSE
+#' qc_input$summaryMethod = "TMP"
 #' loadpage_input$DDA_DIA = "LF"
 #' lf_summarization_loop(testdata, qc_input,loadpage_input, busy_indicator=FALSE)
 #' 

--- a/R/main_calculations.R
+++ b/R/main_calculations.R
@@ -407,7 +407,7 @@ lf_model = function(data, contrast.matrix, busy_indicator = TRUE){
 #' qc_input$remove_norm_channel = TRUE
 #' qc_input$maxQC1 = NULL
 #' qc_input$moderated = FALSE
-#' 
+#' qc_input$summaryMethod = "TMP"
 #' summarization_tmt_test = tmt_summarization_loop(testdata, qc_input, loadpage_input,
 #'                                                busy_indicator = FALSE)
 #'                                                

--- a/R/module-qc-server.R
+++ b/R/module-qc-server.R
@@ -114,7 +114,7 @@ qcServer <- function(input, output, session,parent_session, loadpage_input,get_d
       # } else {
       selectizeInput(ns("which"), "Show plot for", 
                      choices = c("", "ALL PROTEINS" = "allonly", 
-                                 unique(get_data()[1])))
+                                 unique(get_data()$ProteinName)))
       # }
     } else if (loadpage_input()$BIO == "PTM"){
       if (input$type1 == "QCPlot"){
@@ -127,7 +127,7 @@ qcServer <- function(input, output, session,parent_session, loadpage_input,get_d
       }
     } else {
       selectizeInput(ns("which"), "Show plot for", 
-                     choices = c("", unique(get_data()[1])))
+                     choices = c("", unique(get_data()$ProteinName)))
     }
   })
   

--- a/man/lf_summarization_loop.Rd
+++ b/man/lf_summarization_loop.Rd
@@ -47,6 +47,7 @@ qc_input$remove50 = FALSE
 qc_input$maxQC = 0.999
 qc_input$null = FALSE
 qc_input$null1 = FALSE
+qc_input$summaryMethod = "TMP"
 loadpage_input$DDA_DIA = "LF"
 lf_summarization_loop(testdata, qc_input,loadpage_input, busy_indicator=FALSE)
 

--- a/man/tmt_model.Rd
+++ b/man/tmt_model.Rd
@@ -51,7 +51,7 @@ qc_input$reference_norm = TRUE
 qc_input$remove_norm_channel = TRUE
 qc_input$maxQC1 = NULL
 qc_input$moderated = FALSE
-
+qc_input$summaryMethod = "TMP"
 summarization_tmt_test = tmt_summarization_loop(testdata, qc_input, loadpage_input,
                                                busy_indicator = FALSE)
                                                

--- a/man/tmt_summarization_loop.Rd
+++ b/man/tmt_summarization_loop.Rd
@@ -50,6 +50,7 @@ qc_input$global_norm = TRUE
 qc_input$reference_norm = TRUE
 qc_input$remove_norm_channel = TRUE
 qc_input$maxQC1 = NULL
+qc_input$summaryMethod = "TMP"
 summarization_tmt_test = tmt_summarization_loop(testdata, qc_input,loadpage_input, 
                                                busy_indicator = FALSE)
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -992,7 +992,7 @@ test_that("preprocessData QC, PTM and PTMTMT: No", {
     mock_input$filetype = "sample"
     mock_input$norm = "equalizeMedians"
     mock_input$log = "2"
-    mock_input$summaryMethod = "linear"
+    mock_input$summaryMethod = "TMP"
 
     stub(preprocessData,"getData",mockGetData(mock_input))
     stub(preprocessData,"loadpage_input",mock_input)
@@ -1023,7 +1023,7 @@ test_that("preprocessData QC, PTM and PTMTMT: Yes", {
     mock_input$norm = "equalizeMedians"
     mock_input$log = "2"
     mock_input$summarization = "msstats"
-    mock_input$summaryMethod = "linear"
+    mock_input$summaryMethod = "TMP"
 
     stub(preprocessData,"getData",mockGetData(mock_input))
     stub(preprocessData,"loadpage_input",mock_input)
@@ -1084,7 +1084,7 @@ test_that("preprocessData QC Other", {
     mock_input$filetype = "sample"
     mock_input$norm = "equalizeMedians"
     mock_input$log = "2"
-    mock_input$summaryMethod = "linear"
+    mock_input$summaryMethod = "TMP"
 
     stub(preprocessData,"getData",mockGetData(mock_input))
     stub(preprocessData,"loadpage_input",mock_input)
@@ -1218,7 +1218,7 @@ test_that("dataComparison statmodel PTM PTMTMT: No", {
     mock_input$MBi = TRUE
     mock_input$log = "2"
     mock_input$norm = "equalizeMedians"
-    mock_input$summaryMethod = "linear"
+    mock_input$summaryMethod = "TMP"
 
     stub(dataComparison,"loadpage_input",mock_input,2)
     stub(dataComparison,"qc_input",mock_input)
@@ -1322,7 +1322,7 @@ test_that("dataComparison statmodel Other", {
     mock_input$filetype = "sample"
     mock_input$norm = "equalizeMedians"
     mock_input$log = "2"
-    mock_input$summaryMethod = "linear"
+    mock_input$summaryMethod = "TMP"
 
     stub(dataComparison,"loadpage_input",mock_input,2)
     stub(dataComparison,"qc_input",mock_input)


### PR DESCRIPTION
Fix: Replace index-based column lookup with name-based lookup

Processing the run order file reorders the in-memory data, shifting the 'ProteinName' column. The dropdown logic relied on a fixed index, leading to data mismatches.

Updated the code to target the column by name ('ProteinName') to ensure stability regardless of column order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Protein selection dropdown in QC analysis now uses the designated protein-name field, ensuring correct and consistent protein choices across modes.

* **Documentation**
  * Examples updated to show the default summary method set to "TMP" in QC/config documentation.

* **Tests**
  * Test examples and expectations updated to reflect the "TMP" summary method.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->