### PR TITLE
adding some of the tooltips

### DIFF
--- a/R/module-statmodel-server.R
+++ b/R/module-statmodel-server.R
@@ -676,14 +676,18 @@ statmodelServer = function(id, parent_session, loadpage_input, qc_input,
             "table.dataTable td input { color: black !important; }"
           ))),
           h2("Comparison matrix"),
-          p(tags$i("This table is interactive. Click values to edit.")),
+          if (!is.null(input[[NAMESPACE_STATMODEL$comparison_mode]]) &&
+              input[[NAMESPACE_STATMODEL$comparison_mode]] ==
+                CONSTANTS_STATMODEL$comparison_mode_response_curve) {
+            p(tags$i("This table is interactive. Click values to edit."))
+          },
           if (!is.null(input[[NAMESPACE_STATMODEL$comparison_mode]]) &&
               input[[NAMESPACE_STATMODEL$comparison_mode]] %in% c(
                 CONSTANTS_STATMODEL$comparison_mode_all_pairwise,
                 CONSTANTS_STATMODEL$comparison_mode_all_vs_one,
                 CONSTANTS_STATMODEL$comparison_mode_custom_pairwise
               )) {
-            p(tags$i(" -1 means control and 1 means treatment"))
+            p(tags$i(" A value of −1 represents the control group, and a value of 1 represents the treatment group"))
           },
           br(),
           textOutput(ns("message")),

--- a/R/module-statmodel-server.R
+++ b/R/module-statmodel-server.R
@@ -676,11 +676,7 @@ statmodelServer = function(id, parent_session, loadpage_input, qc_input,
             "table.dataTable td input { color: black !important; }"
           ))),
           h2("Comparison matrix"),
-          if (!is.null(input[[NAMESPACE_STATMODEL$comparison_mode]]) &&
-              input[[NAMESPACE_STATMODEL$comparison_mode]] ==
-                CONSTANTS_STATMODEL$comparison_mode_response_curve) {
-            p(tags$i("This table is interactive. Click values to edit."))
-          },
+          p(tags$i("This table is interactive. Click values to edit.")),
           if (!is.null(input[[NAMESPACE_STATMODEL$comparison_mode]]) &&
               input[[NAMESPACE_STATMODEL$comparison_mode]] %in% c(
                 CONSTANTS_STATMODEL$comparison_mode_all_pairwise,

--- a/R/module-statmodel-server.R
+++ b/R/module-statmodel-server.R
@@ -677,6 +677,14 @@ statmodelServer = function(id, parent_session, loadpage_input, qc_input,
           ))),
           h2("Comparison matrix"),
           p(tags$i("This table is interactive. Click values to edit.")),
+          if (!is.null(input[[NAMESPACE_STATMODEL$comparison_mode]]) &&
+              input[[NAMESPACE_STATMODEL$comparison_mode]] %in% c(
+                CONSTANTS_STATMODEL$comparison_mode_all_pairwise,
+                CONSTANTS_STATMODEL$comparison_mode_all_vs_one,
+                CONSTANTS_STATMODEL$comparison_mode_custom_pairwise
+              )) {
+            p(tags$i(" -1 means control and 1 means treatment"))
+          },
           br(),
           textOutput(ns("message")),
           br(),

--- a/R/module-statmodel-server.R
+++ b/R/module-statmodel-server.R
@@ -683,7 +683,7 @@ statmodelServer = function(id, parent_session, loadpage_input, qc_input,
                 CONSTANTS_STATMODEL$comparison_mode_all_vs_one,
                 CONSTANTS_STATMODEL$comparison_mode_custom_pairwise
               )) {
-            p(tags$i(" A value of −1 represents the control group, and a value of 1 represents the treatment group"))
+            p(tags$i("A value of −1 represents the control group, and a value of 1 represents the treatment group"))
           },
           br(),
           textOutput(ns("message")),


### PR DESCRIPTION
adding tool tips for the matrix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the previous static hint with context-aware on-screen hints.
  * The pairwise comparison hint "A value of −1 represents the control group, and a value of 1 represents the treatment group" is now shown only in all_pairwise, all_vs_one, or custom_pairwise modes; otherwise the original hint is retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->