### PR TITLE
feat(metamorpheus): Prepopulate modification ID as a dropdown for PTM conversion

### DIFF
--- a/R/module-loadpage-server.R
+++ b/R/module-loadpage-server.R
@@ -73,19 +73,23 @@ loadpageServer <- function(id, parent_session, is_web_server = FALSE) {
       }
     })
 
-    # Read first 100 rows when main data file changes
+    # Read first 100 rows only for Metamorpheus PTM (the only flow that uses preview_data)
     observe({
-      file_info <- main_data_file()
-      if (!is.null(file_info)) {
-        preview <- tryCatch(
-          data.table::fread(file_info$datapath, nrows = 100, header = TRUE),
-          error = function(e) {
-            showNotification(paste("Could not preview file:", conditionMessage(e)),
-                             type = "warning", duration = 5)
-            NULL
-          }
-        )
-        preview_data(preview)
+      if (isTRUE(input$filetype == "meta") && isTRUE(input$BIO == "PTM")) {
+        file_info <- main_data_file()
+        if (!is.null(file_info)) {
+          preview <- tryCatch(
+            data.table::fread(file_info$datapath, nrows = 100, header = TRUE),
+            error = function(e) {
+              showNotification(paste("Could not preview file:", conditionMessage(e)),
+                               type = "warning", duration = 5)
+              NULL
+            }
+          )
+          preview_data(preview)
+        } else {
+          preview_data(NULL)
+        }
       } else {
         preview_data(NULL)
       }

--- a/R/module-loadpage-server.R
+++ b/R/module-loadpage-server.R
@@ -46,6 +46,89 @@ loadpageServer <- function(id, parent_session, is_web_server = FALSE) {
     else {
       local_big_file_path <- reactive({ NULL })
     }
+
+    # ============ PREVIEW DATA: Read first 100 rows on file upload ============
+    preview_data <- reactiveVal(NULL)
+
+    # Determine the main data file based on current selections
+    main_data_file <- reactive({
+      req(input$filetype)
+      if (input$BIO == "PTM") {
+        switch(input$filetype,
+          "maxq" =, "PD" =, "spec" =, "sky" =, "meta" = input$ptm_input,
+          "phil" = input$ptmdata,
+          "msstats" = input$msstatsptmdata,
+          NULL
+        )
+      } else {
+        switch(input$filetype,
+          "prog" =, "PD" =, "open" =, "openms" =, "spmin" =, "phil" =, "meta" = input$data,
+          "msstats" = input$msstatsdata,
+          "sky" = input$skylinedata,
+          "spec" = input$specdata,
+          "diann" = input$dianndata,
+          "maxq" = input$evidence,
+          NULL
+        )
+      }
+    })
+
+    # Read first 100 rows when main data file changes
+    observe({
+      file_info <- main_data_file()
+      if (!is.null(file_info)) {
+        preview <- tryCatch(
+          data.table::fread(file_info$datapath, nrows = 100, header = TRUE),
+          error = function(e) {
+            showNotification(paste("Could not preview file:", conditionMessage(e)),
+                             type = "warning", duration = 5)
+            NULL
+          }
+        )
+        preview_data(preview)
+      } else {
+        preview_data(NULL)
+      }
+    })
+
+    # ========= METAMORPHEUS PTM: Dynamic modification ID dropdown =========
+    output$mod_id_meta_ui <- renderUI({
+      ns <- session$ns
+      req(input$filetype == "meta", input$BIO == "PTM")
+
+      mods <- .extract_mod_ids_from_preview(preview_data())
+
+      if (length(mods) > 0) {
+        choices <- c(mods, "Other" = "__other__")
+        tagList(
+          h4("Modification IDs", class = "icon-wrapper",
+             icon("question-circle", lib = "font-awesome"),
+             div("Select the modification ID to filter for PTMs. Select Other to manually enter a custom ID pattern (e.g. [Common Biological:Phosphorylation on S]).",
+                 class = "icon-tooltip")),
+          selectizeInput(ns("mod_id_meta_select"),
+                         label = NULL,
+                         choices = choices,
+                         selected = choices[1],
+                         multiple = FALSE),
+          conditionalPanel(
+            condition = paste0("input['", ns("mod_id_meta_select"), "'] == '__other__'"),
+            textInput(ns("mod_id_meta_custom"),
+                      label = h5("Enter modification ID (e.g. [Common Biological:Phosphorylation on S])"),
+                      value = "")
+          )
+        )
+      } else {
+        # Fallback: no preview data or no mods found. Manual entry
+        tagList(
+          h4("Modification IDs", class = "icon-wrapper",
+             icon("question-circle", lib = "font-awesome"),
+             div("Enter the modification ID pattern to filter for PTMs (e.g. phosphorylation pattern from Metamorpheus output).",
+                 class = "icon-tooltip")),
+          textInput(ns("mod_id_meta_custom"), label = NULL,
+                    value = "[Common Biological:Phosphorylation on S]")
+        )
+      }
+    })
     
     output$spectronaut_header_ui <- renderUI({
       req(input$filetype == 'spec', input$BIO != 'PTM')

--- a/R/module-loadpage-server.R
+++ b/R/module-loadpage-server.R
@@ -51,17 +51,24 @@ loadpageServer <- function(id, parent_session, is_web_server = FALSE) {
     preview_data <- reactiveVal(NULL)
 
     # Determine the main data file based on current selections
+    # TODO: Add preview mappings for remaining PTM file types (PD, spec, sky, maxq)
+    # once preview-based UI features are extended beyond Metamorpheus.
     main_data_file <- reactive({
       req(input$filetype)
       if (input$BIO == "PTM") {
         switch(input$filetype,
-          "maxq" =, "PD" =, "spec" =, "sky" =, "meta" = input$ptm_input,
-          "phil" = input$ptmdata,
-          "msstats" = input$msstatsptmdata,
+          "meta" = input$ptm_input,
+          # TODO: "maxq" = input$ptm_input,
+          # TODO: "PD" = input$ptm_input,
+          # TODO: "spec" = input$ptm_input,
+          # TODO: "sky" = input$ptm_input,
+          # TODO: "phil" = input$ptmdata,
+          # TODO: "msstats" = input$msstatsptmdata,
           NULL
         )
       } else {
         switch(input$filetype,
+          # TODO: Map remaining non-PTM file types when preview features are needed
           "prog" =, "PD" =, "open" =, "openms" =, "spmin" =, "phil" =, "meta" = input$data,
           "msstats" = input$msstatsdata,
           "sky" = input$skylinedata,
@@ -73,7 +80,9 @@ loadpageServer <- function(id, parent_session, is_web_server = FALSE) {
       }
     })
 
-    # Read first 100 rows only for Metamorpheus PTM (the only flow that uses preview_data)
+    # Read first 100 rows for Metamorpheus PTM preview.
+    # TODO: Extend preview reading to other input formats (e.g., Spectronaut, MaxQuant)
+    # for dynamic UI updates. Currently limited to Metamorpheus.
     observe({
       if (isTRUE(input$filetype == "meta") && isTRUE(input$BIO == "PTM")) {
         file_info <- main_data_file()
@@ -99,39 +108,16 @@ loadpageServer <- function(id, parent_session, is_web_server = FALSE) {
     output$mod_id_meta_ui <- renderUI({
       ns <- session$ns
       req(input$filetype == "meta", input$BIO == "PTM")
-
       mods <- .extract_mod_ids_from_preview(preview_data())
+      create_meta_mod_id_selector(ns, mods)
+    })
 
-      if (length(mods) > 0) {
-        choices <- c(mods, "Other" = "__other__")
-        tagList(
-          h4("Modification IDs", class = "icon-wrapper",
-             icon("question-circle", lib = "font-awesome"),
-             div("Select the modification ID to filter for PTMs. Select Other to manually enter a custom ID pattern (e.g. [Common Biological:Phosphorylation on S]).",
-                 class = "icon-tooltip")),
-          selectizeInput(ns("mod_id_meta_select"),
-                         label = NULL,
-                         choices = choices,
-                         selected = choices[1],
-                         multiple = FALSE),
-          conditionalPanel(
-            condition = paste0("input['", ns("mod_id_meta_select"), "'] == '__other__'"),
-            textInput(ns("mod_id_meta_custom"),
-                      label = h5("Enter modification ID (e.g. [Common Biological:Phosphorylation on S])"),
-                      value = "")
-          )
-        )
-      } else {
-        # Fallback: no preview data or no mods found. Manual entry
-        tagList(
-          h4("Modification IDs", class = "icon-wrapper",
-             icon("question-circle", lib = "font-awesome"),
-             div("Enter the modification ID pattern to filter for PTMs (e.g. phosphorylation pattern from Metamorpheus output).",
-                 class = "icon-tooltip")),
-          textInput(ns("mod_id_meta_custom"), label = NULL,
-                    value = "[Common Biological:Phosphorylation on S]")
-        )
-      }
+    # Show manual text input when "Other" is selected (replaces conditionalPanel)
+    output$mod_id_meta_other_input <- renderUI({
+      req(input$mod_id_meta_select == "__other__")
+      textInput(session$ns("mod_id_meta_custom"),
+                label = h5("Enter modification ID (e.g. [Common Biological:Phosphorylation on S])"),
+                value = "")
     })
     
     output$spectronaut_header_ui <- renderUI({

--- a/R/module-loadpage-ui.R
+++ b/R/module-loadpage-ui.R
@@ -402,6 +402,39 @@ create_maxquant_uploads <- function(ns) {
   )
 }
 
+#' Create modification ID selector UI for Metamorpheus PTM
+#'
+#' @param ns Namespace function.
+#' @param mod_choices Character vector of modification IDs extracted from preview,
+#'   or empty character(0) if no preview data is available.
+#' @return A tagList with either a dropdown + optional text input, or a fallback text input.
+#' @noRd
+create_meta_mod_id_selector <- function(ns, mod_choices = character(0)) {
+  if (length(mod_choices) > 0) {
+    choices <- c(mod_choices, "Other" = "__other__")
+    tagList(
+      h4("Modification IDs", class = "icon-wrapper",
+         icon("question-circle", lib = "font-awesome"),
+         div("Select the modification ID to filter for PTMs. Select Other to manually enter a custom ID pattern.",
+             class = "icon-tooltip")),
+      selectizeInput(ns("mod_id_meta_select"),
+                     label = NULL,
+                     choices = choices,
+                     selected = choices[1],
+                     multiple = FALSE),
+      uiOutput(ns("mod_id_meta_other_input"))
+    )
+  } else {
+    tagList(
+      h4("Modification IDs", class = "icon-wrapper",
+         icon("question-circle", lib = "font-awesome"),
+         div("Enter the modification ID pattern to filter for PTMs (e.g. phosphorylation pattern from Metamorpheus output).",
+             class = "icon-tooltip")),
+      textInput(ns("mod_id_meta_custom"), label = NULL, value = "")
+    )
+  }
+}
+
 #' Create PTM file uploads (for MaxQuant, PD, Spectronaut, Skyline)
 #' @noRd
 create_ptm_uploads <- function(ns) {

--- a/R/module-loadpage-ui.R
+++ b/R/module-loadpage-ui.R
@@ -443,10 +443,7 @@ create_ptm_uploads <- function(ns) {
         accept = c(".csv", ".tsv")
       ),
 
-      h4("Modification IDs", class = "icon-wrapper",
-         icon("question-circle", lib = "font-awesome"),
-         div("Enter the modification ID pattern to filter for PTMs (e.g. phosphorylation pattern from Metamorpheus output).", class = "icon-tooltip")),
-      textInput(ns("mod_id_meta"), "", value="\\[Common Biological:Phosphorylation on S\\]")
+      uiOutput(ns("mod_id_meta_ui"))
     ),
     
     # PTM modification labels

--- a/R/module-loadpage-ui.R
+++ b/R/module-loadpage-ui.R
@@ -420,8 +420,9 @@ create_meta_mod_id_selector <- function(ns, mod_choices = character(0)) {
       selectizeInput(ns("mod_id_meta_select"),
                      label = NULL,
                      choices = choices,
-                     selected = choices[1],
-                     multiple = FALSE),
+                     selected = NULL,
+                     multiple = FALSE,
+                     options = list(placeholder = "Select a modification...")),
       uiOutput(ns("mod_id_meta_other_input"))
     )
   } else {

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,3 +1,43 @@
+#' Extract unique modification IDs from preview data
+#'
+#' Parses the Full Sequence column to find bracket-enclosed modification IDs.
+#' @param preview_df Data frame with first 100 rows of uploaded file.
+#' @return Character vector of unique modification IDs (clean, no escaping).
+#' @noRd
+.extract_mod_ids_from_preview <- function(preview_df) {
+  if (is.null(preview_df) || nrow(preview_df) == 0) return(character(0))
+
+  col_name <- grep("Full.Sequence|FullSequence|Full Sequence",
+                   names(preview_df), value = TRUE, ignore.case = TRUE)
+  if (length(col_name) == 0) return(character(0))
+
+  sequences <- as.character(preview_df[[col_name[1]]])
+  all_mods <- regmatches(sequences, gregexpr("\\[.*?\\]", sequences))
+  unique_mods <- sort(unique(unlist(all_mods)))
+  return(unique_mods)
+}
+
+#' Resolve the modification ID from dropdown or manual entry
+#'
+#' Returns an escaped modification ID string ready for regex matching.
+#' @param selected The value from the dropdown (mod_id_meta_select).
+#' @param custom The value from the manual text input (mod_id_meta_custom).
+#' @return Character string with escaped brackets for regex.
+#' @noRd
+.resolve_mod_id <- function(selected = NULL, custom = NULL) {
+  if (!is.null(selected) && selected != "__other__") {
+    return(gsub("(\\[|\\])", "\\\\\\1", selected))
+  }
+  if (!is.null(custom) && nchar(custom) > 0) {
+    val <- custom
+    if (!grepl("\\\\\\[", val)) {
+      val <- gsub("(\\[|\\])", "\\\\\\1", val)
+    }
+    return(val)
+  }
+  return("\\[Common Biological:Phosphorylation on S\\]")
+}
+
 # loadpage server functions
 getEvidence <- function(input) {
   evidence = input$evidence
@@ -399,6 +439,9 @@ getData <- function(input) {
         }
       }
       
+      # Resolve mod ID from dropdown or manual entry, escaping brackets for regex
+      mod_id_value <- .resolve_mod_id(input$mod_id_meta_select, input$mod_id_meta_custom)
+
       mydata = MetamorpheusToMSstatsPTMFormat(
         data.table::copy(ptm_data),
         ptm_annotation,
@@ -406,7 +449,7 @@ getData <- function(input) {
         input_protein = if (!is.null(protein_data)) data.table::copy(protein_data) else NULL,
         annotation_protein = protein_annotation,
         use_unmod_peptides = use_unmod_peptides,
-        mod_ids = c(input$mod_id_meta)
+        mod_ids = c(mod_id_value)
       )
     } else {
       data = read.csv(input$msstatsptmdata$datapath, header = TRUE,sep = input$sep_msstatsptmdata, 
@@ -921,13 +964,15 @@ library(MSstatsPTM)\n", sep = "")
         codes = paste(codes, "fasta_path = \"insert your FASTA filepath\"\n", sep = "")
         codes = paste(codes, "# Optional: set protein_data = NULL if no GlobalProteome data\nprotein_data = tryCatch(data.table::fread(\"insert your GlobalProteome AllQuantifiedPeaks.tsv filepath\"), error = function(e) NULL)\n", sep = "")
         codes = paste(codes, "annot_protein = if (!is.null(protein_data)) read.csv(\"insert your GlobalProteome annotation filepath\") else NULL\n", sep = "")
+        # Resolve mod ID for generated code
+        code_mod_id <- .resolve_mod_id(input$mod_id_meta_select, input$mod_id_meta_custom)
         codes = paste(codes, "use_unmod_peptides = FALSE\ndata = MetamorpheusToMSstatsPTMFormat(data.table::copy(ptm_data),
                                        annot,
                                        fasta_path = fasta_path,
                                        input_protein = protein_data,
                                        annotation_protein = annot_protein,
                                        use_unmod_peptides = use_unmod_peptides,
-                                       mod_ids = c(\"", gsub('"', '\\\\"', gsub("\\\\", "\\\\\\\\", input$mod_id_meta)), "\"))\n", sep = "")
+                                       mod_ids = c(\"", gsub('"', '\\\\"', gsub("\\\\", "\\\\\\\\", code_mod_id)), "\"))\n", sep = "")
       } else {
         codes = paste(codes, "data = data.table::fread(\"insert your QuantifiedPeaks.tsv filepath\")\nannot_file = read.csv(\"insert your annotation filepath\")\n"
                       , sep = "")

--- a/R/utils.R
+++ b/R/utils.R
@@ -12,7 +12,7 @@
   if (length(col_name) == 0) return(character(0))
 
   sequences <- as.character(preview_df[[col_name[1]]])
-  all_mods <- regmatches(sequences, gregexpr("\\[.*?\\]", sequences))
+  all_mods <- regmatches(sequences, gregexpr("\\[[^\\]]+\\]", sequences, perl = TRUE))
   unique_mods <- sort(unique(unlist(all_mods)))
   return(unique_mods)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -30,9 +30,10 @@
   }
   if (!is.null(custom) && nchar(custom) > 0) {
     val <- custom
-    if (!grepl("\\\\\\[", val)) {
-      val <- gsub("(\\[|\\])", "\\\\\\1", val)
-    }
+    # Normalize: strip any existing escapes, then re-escape both brackets
+    val <- gsub("\\\\\\[", "[", val)
+    val <- gsub("\\\\\\]", "]", val)
+    val <- gsub("(\\[|\\])", "\\\\\\1", val)
     return(val)
   }
   stop("No modification ID selected. Please select a modification from the dropdown or enter one manually.")
@@ -983,7 +984,13 @@ library(MSstatsPTM)\n", sep = "")
         codes = paste(codes, "# Optional: set protein_data = NULL if no GlobalProteome data\nprotein_data = tryCatch(data.table::fread(\"insert your GlobalProteome AllQuantifiedPeaks.tsv filepath\"), error = function(e) NULL)\n", sep = "")
         codes = paste(codes, "annot_protein = if (!is.null(protein_data)) read.csv(\"insert your GlobalProteome annotation filepath\") else NULL\n", sep = "")
         # Resolve mod ID for generated code
-        code_mod_id <- .resolve_mod_id(input$mod_id_meta_select, input$mod_id_meta_custom)
+        code_mod_id <- tryCatch(
+          .resolve_mod_id(input$mod_id_meta_select, input$mod_id_meta_custom),
+          error = function(e) {
+            showNotification(conditionMessage(e), type = "error", duration = 8)
+            return("\\[UNSET_MODIFICATION_ID\\]")
+          }
+        )
         codes = paste(codes, "use_unmod_peptides = FALSE\ndata = MetamorpheusToMSstatsPTMFormat(data.table::copy(ptm_data),
                                        annot,
                                        fasta_path = fasta_path,

--- a/R/utils.R
+++ b/R/utils.R
@@ -35,7 +35,7 @@
     }
     return(val)
   }
-  return("\\[Common Biological:Phosphorylation on S\\]")
+  stop("No modification ID selected. Please select a modification from the dropdown or enter one manually.")
 }
 
 # loadpage server functions
@@ -440,17 +440,35 @@ getData <- function(input) {
       }
       
       # Resolve mod ID from dropdown or manual entry, escaping brackets for regex
-      mod_id_value <- .resolve_mod_id(input$mod_id_meta_select, input$mod_id_meta_custom)
-
-      mydata = MetamorpheusToMSstatsPTMFormat(
-        data.table::copy(ptm_data),
-        ptm_annotation,
-        fasta_path = input$fasta$datapath,
-        input_protein = if (!is.null(protein_data)) data.table::copy(protein_data) else NULL,
-        annotation_protein = protein_annotation,
-        use_unmod_peptides = use_unmod_peptides,
-        mod_ids = c(mod_id_value)
+      mod_id_value <- tryCatch(
+        .resolve_mod_id(input$mod_id_meta_select, input$mod_id_meta_custom),
+        error = function(e) {
+          remove_modal_spinner()
+          showNotification(conditionMessage(e), type = "error", duration = 8)
+          return(NULL)
+        }
       )
+      if (is.null(mod_id_value)) return(NULL)
+
+      mydata = tryCatch(
+        MetamorpheusToMSstatsPTMFormat(
+          data.table::copy(ptm_data),
+          ptm_annotation,
+          fasta_path = input$fasta$datapath,
+          input_protein = if (!is.null(protein_data)) data.table::copy(protein_data) else NULL,
+          annotation_protein = protein_annotation,
+          use_unmod_peptides = use_unmod_peptides,
+          mod_ids = c(mod_id_value)
+        ),
+        error = function(e) {
+          remove_modal_spinner()
+          showNotification(
+            paste("Failed to process Metamorpheus PTM data. Please check your modification ID and input files:", conditionMessage(e)),
+            type = "error", duration = 10)
+          return(NULL)
+        }
+      )
+      if (is.null(mydata)) return(NULL)
     } else {
       data = read.csv(input$msstatsptmdata$datapath, header = TRUE,sep = input$sep_msstatsptmdata, 
                       stringsAsFactors=FALSE)

--- a/tests/testthat/test-module-loadpage-ui.R
+++ b/tests/testthat/test-module-loadpage-ui.R
@@ -464,10 +464,9 @@ test_that("Metamorpheus PTM upload fields exist in UI", {
   result <- loadpageUI("test")
   html_output <- as.character(result)
 
-  expect_true(grepl("mod_id_meta", html_output),
-              info = "Metamorpheus PTM modification ID field not found in UI")
+  # Modification IDs section is now a dynamic uiOutput (rendered server-side)
+  expect_true(grepl("mod_id_meta_ui", html_output),
+              info = "Metamorpheus PTM modification ID uiOutput placeholder not found in UI")
   expect_true(grepl("ptm_protein_annot", html_output),
               info = "Metamorpheus PTM protein annotation upload not found in UI")
-  expect_true(grepl("Modification IDs", html_output),
-              info = "Metamorpheus PTM Modification IDs label not found in UI")
 })

--- a/tests/testthat/test-module-loadpage-ui.R
+++ b/tests/testthat/test-module-loadpage-ui.R
@@ -470,3 +470,25 @@ test_that("Metamorpheus PTM upload fields exist in UI", {
   expect_true(grepl("ptm_protein_annot", html_output),
               info = "Metamorpheus PTM protein annotation upload not found in UI")
 })
+
+test_that("create_meta_mod_id_selector shows dropdown when mods are available", {
+  ui <- MSstatsShiny:::create_meta_mod_id_selector(
+    shiny::NS("test"),
+    c("[Mod A]", "[Mod B]")
+  )
+  html <- as.character(ui)
+  expect_true(grepl("mod_id_meta_select", html))
+  expect_true(grepl("Mod A", html))
+  expect_true(grepl("Mod B", html))
+  expect_true(grepl("__other__", html))
+})
+
+test_that("create_meta_mod_id_selector shows text input when no mods available", {
+  ui <- MSstatsShiny:::create_meta_mod_id_selector(
+    shiny::NS("test"),
+    character(0)
+  )
+  html <- as.character(ui)
+  expect_true(grepl("mod_id_meta_custom", html))
+  expect_false(grepl("mod_id_meta_select", html))
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -540,7 +540,8 @@ test_that("ptm metamorpheus", {
     mock_input$BIO <- "PTM"
     mock_input$DDA_DIA <- "LType"
     mock_input$filetype <- "meta"
-    mock_input$mod_id_meta <- "\\[Common Fixed:Carbamidomethyl on C\\]"
+    mock_input$mod_id_meta_select <- "[Common Fixed:Carbamidomethyl on C]"
+    mock_input$mod_id_meta_custom <- NULL
     mock_input$ptm_input$datapath <- system.file(
       "tinytest/raw_data/Metamorpheus/AllQuantifiedPeaks.tsv",
       package = "MSstatsPTM")
@@ -1628,4 +1629,17 @@ test_that("resolve_mod_id returns default when both inputs are NULL", {
 test_that("resolve_mod_id returns default when custom is empty string", {
   result <- MSstatsShiny:::.resolve_mod_id("__other__", "")
   expect_equal(result, "\\[Common Biological:Phosphorylation on S\\]")
+})
+
+test_that("extract_mod_ids_from_preview handles consecutive modifications", {
+  preview <- data.frame(
+    `Full Sequence` = c(
+      "A[Mod1][Mod2]B[Mod3]C"
+    ),
+    check.names = FALSE
+  )
+
+  result <- MSstatsShiny:::.extract_mod_ids_from_preview(preview)
+  expect_equal(length(result), 3)
+  expect_true(all(c("[Mod1]", "[Mod2]", "[Mod3]") %in% result))
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1621,6 +1621,14 @@ test_that("resolve_mod_id preserves already-escaped custom input", {
   expect_equal(result, "\\[Already Escaped\\]")
 })
 
+test_that("resolve_mod_id fixes partially escaped custom input", {
+  result <- MSstatsShiny:::.resolve_mod_id(
+    selected = "__other__",
+    custom = "\\[Phospho]"
+  )
+  expect_equal(result, "\\[Phospho\\]")
+})
+
 test_that("resolve_mod_id errors when both inputs are NULL", {
   expect_error(MSstatsShiny:::.resolve_mod_id(NULL, NULL),
                "No modification ID selected")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1591,3 +1591,41 @@ describe("getData for Big Spectronaut", {
     expect_null(res)
   })
 })
+
+# ============================================================================
+# MOD ID RESOLUTION TESTS
+# ============================================================================
+
+test_that("resolve_mod_id uses dropdown selection and escapes brackets", {
+  result <- MSstatsShiny:::.resolve_mod_id(
+    selected = "[Common Fixed:Carbamidomethyl on C]",
+    custom = NULL
+  )
+  expect_equal(result, "\\[Common Fixed:Carbamidomethyl on C\\]")
+})
+
+test_that("resolve_mod_id uses custom input when Other is selected", {
+  result <- MSstatsShiny:::.resolve_mod_id(
+    selected = "__other__",
+    custom = "[My Custom Mod]"
+  )
+  expect_equal(result, "\\[My Custom Mod\\]")
+})
+
+test_that("resolve_mod_id preserves already-escaped custom input", {
+  result <- MSstatsShiny:::.resolve_mod_id(
+    selected = "__other__",
+    custom = "\\[Already Escaped\\]"
+  )
+  expect_equal(result, "\\[Already Escaped\\]")
+})
+
+test_that("resolve_mod_id returns default when both inputs are NULL", {
+  result <- MSstatsShiny:::.resolve_mod_id(NULL, NULL)
+  expect_equal(result, "\\[Common Biological:Phosphorylation on S\\]")
+})
+
+test_that("resolve_mod_id returns default when custom is empty string", {
+  result <- MSstatsShiny:::.resolve_mod_id("__other__", "")
+  expect_equal(result, "\\[Common Biological:Phosphorylation on S\\]")
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1621,14 +1621,14 @@ test_that("resolve_mod_id preserves already-escaped custom input", {
   expect_equal(result, "\\[Already Escaped\\]")
 })
 
-test_that("resolve_mod_id returns default when both inputs are NULL", {
-  result <- MSstatsShiny:::.resolve_mod_id(NULL, NULL)
-  expect_equal(result, "\\[Common Biological:Phosphorylation on S\\]")
+test_that("resolve_mod_id errors when both inputs are NULL", {
+  expect_error(MSstatsShiny:::.resolve_mod_id(NULL, NULL),
+               "No modification ID selected")
 })
 
-test_that("resolve_mod_id returns default when custom is empty string", {
-  result <- MSstatsShiny:::.resolve_mod_id("__other__", "")
-  expect_equal(result, "\\[Common Biological:Phosphorylation on S\\]")
+test_that("resolve_mod_id errors when custom is empty string", {
+  expect_error(MSstatsShiny:::.resolve_mod_id("__other__", ""),
+               "No modification ID selected")
 })
 
 test_that("extract_mod_ids_from_preview handles consecutive modifications", {


### PR DESCRIPTION
Refactor Loadpage UI & Server to Read First 100 Rows Upon Upload and populate the modification ID dropdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation and Context

The Loadpage module required manual entry of Metamorpheus PTM modification-ID patterns, which is error-prone and reduces usability. This PR improves UX by reading the first 100 rows of an uploaded Metamorpheus ("meta") file when BIO == "PTM", extracting bracket-enclosed modification IDs from the sequence column, and prepopulating a modification-ID selector. If preview fails or no IDs are found, the UI falls back to a manual text input.

## Detailed Changes

- R/module-loadpage-server.R
  - Added reactive state:
    - preview_data <- reactiveVal(NULL)
    - main_data_file <- reactive(...) to select the primary uploaded file input based on input$filetype and input$BIO (PTM-focused).
  - Added an observe() that, when input$filetype == "meta" and input$BIO == "PTM", reads up to the first 100 rows via data.table::fread(..., nrows = 100, header = TRUE). On read error, shows a Shiny warning notification and sets preview_data(NULL); otherwise stores the preview.
  - Introduced server-rendered UI outputs for modification-ID selection:
    - output$mod_id_meta_ui <- renderUI({ mods <- .extract_mod_ids_from_preview(preview_data()); create_meta_mod_id_selector(ns, mods) })
    - output$mod_id_meta_other_input <- renderUI({ textInput(ns("mod_id_meta_custom"), ...) }) shown when select == "__other__".
  - Replaced direct use of input$mod_id_meta in PTM processing with resolution via .resolve_mod_id(input$mod_id_meta_select, input$mod_id_meta_custom); added tryCatch to surface resolution errors and abort processing when needed.

- R/module-loadpage-ui.R
  - Replaced static textInput(ns("mod_id_meta"), ...) in create_ptm_uploads(ns) with uiOutput(ns("mod_id_meta_ui")), delegating rendering of the modification-ID field to server logic.
  - Added create_meta_mod_id_selector(ns, mod_choices = character(0)):
    - When mod_choices non-empty: renders selectizeInput(ns("mod_id_meta_select"), choices = c(mod_choices, "__other__")) plus uiOutput(ns("mod_id_meta_other_input")) for custom input when "__other__" selected.
    - When no mod_choices: renders fallback textInput(ns("mod_id_meta_custom"), ...).

- R/utils.R
  - Added .extract_mod_ids_from_preview(preview_df):
    - Detects a "Full Sequence"/"Full.Sequence"/"FullSequence" column (case-insensitive), extracts bracket-enclosed tokens (regex \[[^\]]+\]), unescapes and returns unique sorted tokens.
  - Added .resolve_mod_id(selected = NULL, custom = NULL):
    - If selected is present and not "__other__", returns selected with square brackets regex-escaped.
    - If selected == "__other__", uses custom (preserves already-escaped custom values or escapes brackets if needed).
    - Throws an error when neither selected nor custom provide a usable value.
  - Updated PTM getData and getDataCode paths to use .resolve_mod_id(...) for mod_ids embedding and added safer error handling and a placeholder fallback in emitted code generation.

- Other wiring
  - Removed client-side conditionalPanel for the "Other" custom input; server now renders that input via output$mod_id_meta_other_input.
  - main_data_file reactive currently targets Metamorpheus ("meta") PTM preview; notes remain for extending previews to other PTM sources.

## Unit Tests Added or Modified

- tests/testthat/test-utils.R
  - Replaced mock_input$mod_id_meta with mock_input$mod_id_meta_select (unescaped bracketed ID) and mock_input$mod_id_meta_custom.
  - Added "MOD ID RESOLUTION TESTS" covering:
    - .resolve_mod_id() escapes dropdown-selected bracketed IDs.
    - Selecting "__other__" uses custom input and preserves or correctly escapes brackets.
    - Already-escaped custom values are preserved (no double-escape).
    - Partially-escaped custom values are normalized.
    - Errors when neither selected nor custom provided or when custom is empty with "__other__" selected.
  - Added tests for .extract_mod_ids_from_preview() to ensure extraction of multiple/consecutive bracketed tokens from preview sequences.

- tests/testthat/test-module-loadpage-ui.R
  - Updated tests to expect uiOutput(ns("mod_id_meta_ui")) instead of a static mod_id_meta input id.
  - Added tests verifying create_meta_mod_id_selector renders:
    - a selectizeInput (mod_id_meta_select) with provided mod labels plus "__other__" when mods available.
    - a custom text input (mod_id_meta_custom) when no mods are available.
  - Removed assertion for the literal "Modification IDs" label.

## Coding Guidelines

- No coding guideline violations detected:
  - Reactive constructs (reactiveVal/reactive/observe) are used appropriately.
  - User-facing errors on preview read failure are surfaced via showNotification.
  - New helper functions are internal (dot-prefixed) and focused.
  - Tests were added/updated to cover extraction and resolution logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->