### PR TITLE
feat(visualization-code): Add event handler for edge deletion

### DIFF
--- a/R/MSstatsShiny.R
+++ b/R/MSstatsShiny.R
@@ -36,7 +36,7 @@
 #' @importFrom tidyr unite pivot_wider
 #' @importFrom MSstatsConvert MSstatsLogsSettings
 #' @importFrom MSstatsPTM dataProcessPlotsPTM groupComparisonPlotsPTM MaxQtoMSstatsPTMFormat PDtoMSstatsPTMFormat FragPipetoMSstatsPTMFormat SkylinetoMSstatsPTMFormat MetamorpheusToMSstatsPTMFormat SpectronauttoMSstatsPTMFormat
-#' @importFrom MSstatsBioNet exportNetworkToHTML
+#' @importFrom MSstatsBioNet exportNetworkToHTML deleteEdgeFromNetwork
 #' @importFrom utils capture.output head packageVersion read.csv read.delim write.csv
 #' @importFrom stats aggregate
 #' @importFrom methods is

--- a/R/module-visualize-network-server.R
+++ b/R/module-visualize-network-server.R
@@ -289,9 +289,12 @@ visualizeNetworkServer <- function(id, parent_session, dataComparison) {
   
   # Reactive value to store selected proteins
   selectedProteinsReactive <- reactiveVal(character(0))
-  
+
   # Reactive value to store search results
   proteinSearchResults <- reactiveVal(NULL)
+
+  # Reactive value to accumulate edges deleted interactively in the visualization
+  deletedEdges <- reactiveVal(list())
   
   # Render selected proteins as tags
   output$selectedProteinsTags <- renderUI({
@@ -593,7 +596,10 @@ visualizeNetworkServer <- function(id, parent_session, dataComparison) {
   # Event observers
   observeEvent(input$showNetwork, {
     req(df(), getInputParameters(input, selectedProteinsReactive()))
-    
+
+    # Reset deleted edges whenever a fresh network is rendered
+    deletedEdges(list())
+
     # Show loading indicator
     shinyjs::show("loadingIndicator")
     
@@ -647,6 +653,28 @@ visualizeNetworkServer <- function(id, parent_session, dataComparison) {
         if (is.null(code_content) || length(code_content) == 0) {
           stop("No code generated. Please ensure network is displayed first.")
         }
+
+        deleted <- deletedEdges()
+        if (length(deleted) > 0) {
+          deletion_lines <- vapply(deleted, function(e) {
+            sprintf(
+              'subnetwork$edges <- MSstatsBioNet::deleteEdgeFromNetwork(subnetwork$edges, "%s", "%s", "%s")',
+              e$source, e$target, e$interaction
+            )
+          }, character(1))
+          edge_deletion_section <- paste0(
+            "\n# Delete edges removed interactively\n",
+            paste(deletion_lines, collapse = "\n"),
+            "\n"
+          )
+          code_content <- sub(
+            "# Visualize network",
+            paste0(edge_deletion_section, "# Visualize network"),
+            code_content,
+            fixed = TRUE
+          )
+        }
+
         writeLines(code_content, file)
       }, error = function(e) {
         showNotification(
@@ -671,6 +699,12 @@ visualizeNetworkServer <- function(id, parent_session, dataComparison) {
     }
   )
   
+  # Observe edge deletion events from the visualization
+  observeEvent(input$network_edge_deleted, {
+    edge_data <- input$network_edge_deleted
+    deletedEdges(c(deletedEdges(), list(edge_data)))
+  })
+
   # Observe edge click events
   observeEvent(input$network_edge_clicked, {
     edge_data <- input$network_edge_clicked

--- a/R/module-visualize-network-server.R
+++ b/R/module-visualize-network-server.R
@@ -295,6 +295,9 @@ visualizeNetworkServer <- function(id, parent_session, dataComparison) {
 
   # Reactive value to accumulate edges deleted interactively in the visualization
   deletedEdges <- reactiveVal(list())
+
+  # Reactive value tracking the live edges table (updated as edges are deleted)
+  currentEdgesTable <- reactiveVal(NULL)
   
   # Render selected proteins as tags
   output$selectedProteinsTags <- renderUI({
@@ -623,8 +626,9 @@ visualizeNetworkServer <- function(id, parent_session, dataComparison) {
       )
     })
     
-    # Render data tables
+    # Render data tables and seed the live edges state
     renderDataTables(output, render_data$nodes_table, render_data$edges_table)
+    currentEdgesTable(render_data$edges_table)
     
     # Hide loading indicator and re-enable button when done
     shinyjs::hide("loadingIndicator")
@@ -703,14 +707,30 @@ visualizeNetworkServer <- function(id, parent_session, dataComparison) {
   observeEvent(input$network_edge_deleted, {
     edge_data <- input$network_edge_deleted
     deletedEdges(c(deletedEdges(), list(edge_data)))
+
+    updated_edges <- MSstatsBioNet::deleteEdgeFromNetwork(
+      currentEdgesTable(),
+      edge_data$source,
+      edge_data$target,
+      edge_data$interaction
+    )
+    currentEdgesTable(updated_edges)
+
+    output$edgesTable <- DT::renderDT({
+      DT::datatable(
+        updated_edges,
+        options = list(pageLength = 10, searchable = TRUE,
+                       scrollX = TRUE, autoWidth = TRUE),
+        selection = "single"
+      )
+    })
   })
 
   # Observe edge click events
   observeEvent(input$network_edge_clicked, {
     edge_data <- input$network_edge_clicked
-    network_data <- renderNetwork()
-    req(network_data)
-    edges_table <- network_data$edges_table
+    edges_table <- currentEdgesTable()
+    req(edges_table)
     highlightEdgeInTable(output, edge_data, edges_table)
   })
   

--- a/R/module-visualize-network-server.R
+++ b/R/module-visualize-network-server.R
@@ -48,13 +48,13 @@ highlightEdgeInTable <- function(output, edge_data, edges_table) {
   req(edge_data$source, edge_data$target, edge_data$interaction)
   source <- edge_data$source
   target <- edge_data$target
-  interaction <- gsub(" \\(bidirectional\\)", "", edge_data$interaction)
+  interaction <- edge_data$interaction
   edge_type <- edge_data$edge_type
   
   # Find matching rows
-  if (edge_type %in% c("undirected", "bidirectional")) {
+  if (edge_type == "undirected") {
     
-    # For undirected or bidirectional edges, match source and target regardless of order
+    # For undirected edges, match source and target regardless of order
     row_indices <- which(((edges_table$source == source & edges_table$target == target) |
                             (edges_table$source == target & edges_table$target == source)) &
                            (edges_table$interaction == interaction))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

This PR implements interactive edge deletion functionality in the network visualization module. Previously, users could visualize network graphs and see edge information in tables, but could not dynamically remove edges from the visualization. The solution introduces reactive state management to track deleted edges, updates the live edges table as deletions occur, and ensures that exported R code reflects these interactive changes so users can reproduce their analysis in standalone scripts.

## Detailed Changes

### R/MSstatsShiny.R
- Added import of `deleteEdgeFromNetwork` function from the `MSstatsBioNet` package to enable edge deletion operations

### R/module-visualize-network-server.R

**New Reactive State Management:**
- `deletedEdges`: Reactive values object that accumulates edges deleted interactively by the user throughout the session
- `currentEdgesTable`: Reactive expression maintaining the live edges table that reflects all deletions made during the current visualization session

**Network Display and Initialization:**
- When `input$showNetwork` triggers:
  - `deletedEdges` is reset to an empty list to start fresh with each new network visualization
  - Both `nodesTable` and `edgesTable` data tables are rendered with the freshly generated network data
  - `currentEdgesTable` is seeded with the complete, unmodified edges table

**Edge Deletion Observer (`input$network_edge_deleted`):**
- New observer that listens for edge deletion events from the interactive network visualization:
  - Appends the deleted edge data (source, target, interaction type) to `deletedEdges`
  - Updates `currentEdgesTable` by calling `MSstatsBioNet::deleteEdgeFromNetwork()` to remove the edge from the table
  - Re-renders `output$edgesTable` with the updated edges, reflecting the deletion in real-time

**Edge Click Handling Update:**
- Modified the edge click observer to use `currentEdgesTable()` instead of reconstructing network data from `renderNetwork()`, ensuring that table highlighting correctly reflects the live (possibly edited) edges set with all interactive deletions applied

**Code Download Feature Enhancement:**
- Updated the code generation function to conditionally inject edge deletion statements into the downloadable R script:
  - When edges have been deleted interactively, the script includes `subnetwork$edges <- MSstatsBioNet::deleteEdgeFromNetwork(...)` calls for each deleted edge
  - Allows users to reproduce their interactive deletions in standalone R code without needing the Shiny interface
  - Edge deletion commands are inserted before the network visualization code in the script

## Unit Tests

No new tests were added or modified in this PR. The existing test file `tests/testthat/test_network_visualization.R` does not contain tests specific to the edge deletion functionality introduced in this change.

## Coding Guidelines

The following style guideline violations were identified in `R/module-visualize-network-server.R`:

- **Trailing whitespace**: Extensive trailing whitespace on multiple lines (lines 6, 7, 12, 14, 15, 18, 28, 31, 35, 37, 38, 41, 53, 56, 63, 64, 67, 71, 73, 74, and others). This violates the tidyverse style guide convention of not including trailing whitespace in code lines.

These are minor whitespace issues that do not affect functionality but should be cleaned up in a future commit or addressed in a follow-up PR to maintain code cleanliness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->