### PR TITLE
fix(turnover): Adjust response curve visualization to have a zero heavy ratio for zero timepoint

### DIFF
--- a/R/module-statmodel-server.R
+++ b/R/module-statmodel-server.R
@@ -456,7 +456,7 @@ statmodelServer = function(id, parent_session, loadpage_input, qc_input,
                    CONSTANTS_STATMODEL$plot_type_response_curve) {
           if (app_template() == TEMPLATES$protein_turnover) {
             req(turnover_ratios())
-            dia_prepared <- prepare_turnover_for_dose_response(turnover_ratios())
+            dia_prepared <- prepare_turnover_for_dose_response(turnover_ratios(), add_zero_timepoint = TRUE)
           } else {
             meta <- condition_metadata()
             req(!is.null(meta) && "DoseVal" %in% colnames(meta))

--- a/R/statmodel-server-comparisons.R
+++ b/R/statmodel-server-comparisons.R
@@ -367,7 +367,7 @@ build_all_pair_contrast = function(input, condition_list, contrast, comp_list, r
 #'   H_frac columns required)
 #' @return Data frame with columns: protein, drug, dose, response
 #' @noRd
-prepare_turnover_for_dose_response <- function(ratios) {
+prepare_turnover_for_dose_response <- function(ratios, add_zero_timepoint = FALSE) {
   result <- ratios[!is.na(ratios$H_frac), ]
   result$protein  <- as.character(result$Protein)
   result$drug     <- "time"
@@ -377,7 +377,29 @@ prepare_turnover_for_dose_response <- function(ratios) {
   if ("BaseSequence" %in% colnames(result)) {
     keep_cols <- c(keep_cols, "BaseSequence")
   }
-  result[, keep_cols]
+  result <- result[, keep_cols]
+
+  if (add_zero_timepoint) {
+    group_cols  <- intersect(c("protein", "BaseSequence"), keep_cols)
+    all_groups  <- unique(result[, group_cols, drop = FALSE])
+    zero_groups <- unique(result[result$dose == 0, group_cols, drop = FALSE])
+    if (nrow(zero_groups) == 0) {
+      needs_zero <- all_groups
+    } else {
+      in_zero    <- do.call(paste, all_groups[, group_cols, drop = FALSE]) %in%
+                    do.call(paste, zero_groups[, group_cols, drop = FALSE])
+      needs_zero <- all_groups[!in_zero, , drop = FALSE]
+    }
+    if (nrow(needs_zero) > 0) {
+      zero_rows          <- needs_zero
+      zero_rows$drug     <- "time"
+      zero_rows$dose     <- 0
+      zero_rows$response <- 0
+      result <- rbind(zero_rows[, keep_cols], result)
+    }
+  }
+
+  result
 }
 
 

--- a/R/statmodel-server-visualization.R
+++ b/R/statmodel-server-visualization.R
@@ -188,7 +188,7 @@ create_download_plot_handler <- function(output, input, contrast, preprocess_dat
                 showNotification("Turnover ratios not yet calculated.", type = "error")
                 return(NULL)
               }
-              dia_prepared <- prepare_turnover_for_dose_response(ratios)
+              dia_prepared <- prepare_turnover_for_dose_response(ratios, add_zero_timepoint = TRUE)
             } else {
               if (isTRUE(app_template() == TEMPLATES$chemoproteomics)) {
                 meta <- tryCatch(condition_metadata(), error = function(e) NULL)


### PR DESCRIPTION
## Summary
                                                                                
  - Adds a synthetic zero-timepoint row to the protein turnover visualization
  when no dose == 0 entry exists for a given protein/peptide group              
  - Adds an add_zero_timepoint parameter to prepare_turnover_for_dose_response()
   (defaults to FALSE for backward compatibility) and passes TRUE from both the 
  interactive and download plot paths
  - Ensures the response curve anchors at (0, 0) for all proteins, giving a     
  consistent visual baseline across the time-course plot                        
   
## Why                            
                                               
The MSstats turnover model does not always produce an explicit zero-timepoint ratio. Without a (time=0, H_frac=0) anchor, the fitted response curve can appear to start at an arbitrary time, making the visualization misleading.    
        
