### PR TITLE
fix(turnover): Order group by numerical time value for QC plot

### DIFF
--- a/R/module-qc-server.R
+++ b/R/module-qc-server.R
@@ -197,7 +197,7 @@ qcServer <- function(input, output, session, parent_session, loadpage_input, get
       meta <- get_condition_metadata()
       meta_with_time <- meta[!is.na(meta$TimeVal), ]
       if (nrow(meta_with_time) > 0) {
-        ordered_conditions <- meta_with_time$Condition[order(meta_with_time$TimeVal)]
+        ordered_conditions <- meta_with_time$Condition[order(as.numeric(meta_with_time$TimeVal))]
         all_groups <- unique(as.character(data$FeatureLevelData$GROUP))
         remaining <- setdiff(all_groups, ordered_conditions)
         final_levels <- c(ordered_conditions, remaining)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

The protein turnover analysis workflow in MSstatsShiny requires chronologically ordered time-point groups for proper QC visualization. When metadata `TimeVal` (time values) are imported as factors or character strings rather than numeric values, the `order()` function performs string-based or factor-level ordering instead of numeric ordering. This results in incorrect temporal sequencing (e.g., "10" before "2" in alphabetical order) when determining GROUP factor levels used in downstream QC plots, causing the QC visualizations to misrepresent the temporal progression of samples.

**Solution**: The fix explicitly converts `meta_with_time$TimeVal` to numeric using `as.numeric()` before passing it to the `order()` function in the `ordered_preprocess_data()` reactive function (line 200). This ensures consistent numeric ordering regardless of the input data type.

## Changes

- **R/module-qc-server.R** (lines 192-212): Modified the `ordered_preprocess_data()` reactive function
  - Line 200: Changed `order(meta_with_time$TimeVal)` to `order(as.numeric(meta_with_time$TimeVal))`
  - Impact: Ensures TimeVal values are converted to numeric before being used as the sorting key for ordering conditions
  - The function filters metadata to rows with non-NA TimeVal values, orders conditions numerically by time values, and applies the resulting factor level sequence to both `FeatureLevelData$GROUP` and `ProteinLevelData$GROUP` 
  - This ordered data is used downstream in the QC plot generation function (line 257) when calling `dataProcessPlots(data = ordered_preprocess_data(), ...)`

## Unit Tests

Relevant test cases exist in `tests/testthat/test-module-turnover.R` that validate TimeVal handling:
- **Line 120-136**: `test_that("prepare_turnover_for_dose_response coerces TimeVal to numeric dose", ...)` - Tests that TimeVal is coerced to numeric, including handling of character input ("4")
- Multiple additional test cases validate TimeVal in various scenarios (lines 28, 44, 60, 78, 96, 110, 123, 221)

No dedicated unit tests were found that specifically test the `ordered_preprocess_data()` function's GROUP factor reordering behavior. The related `prepare_turnover_for_dose_response()` function demonstrates the expected pattern of explicit numeric coercion.

## Coding Guidelines

No coding guideline violations were identified. The implementation follows R best practices by:
- Using the base `as.numeric()` function for robust type conversion
- Maintaining defensive programming with null checks and row count validation before factor reordering
- Consistent with the existing pattern used in related functions like `prepare_turnover_for_dose_response()` which also applies `as.numeric()` to TimeVal

<!-- end of auto-generated comment: release notes by coderabbit.ai -->