### PR TITLE
fix(DIANN): Adjust converter to pass NULL labeled amino acid for protein

### DIFF
--- a/R/module-loadpage-server.R
+++ b/R/module-loadpage-server.R
@@ -167,6 +167,18 @@ loadpageServer <- function(id, parent_session, is_web_server = FALSE, app_templa
       )
     })
 
+    output$diann_turnover_ui <- renderUI({
+      req(input$filetype == 'diann', input$DDA_DIA == 'LType')
+      req(!is.null(app_template) && app_template() == TEMPLATES$protein_turnover)
+
+      ns <- session$ns
+      textInput(ns("diann_labeled_aa"),
+                h5("SILAC-labeled amino acids", class = "icon-wrapper",
+                   icon("question-circle", lib = "font-awesome"),
+                   div("Comma-separated single-letter codes of SILAC-labeled amino acids (e.g. K for lysine, or K,R for lysine and arginine).", class = "icon-tooltip")),
+                value = "K")
+    })
+
     output$spectronaut_options_ui <- renderUI({
       req(input$filetype == 'spec', input$BIO != 'PTM')
       

--- a/R/module-loadpage-ui.R
+++ b/R/module-loadpage-ui.R
@@ -611,14 +611,7 @@ create_label_free_options <- function(ns) {
                      div("Enter the column name containing intensity values for DIANN versions prior to 2.0", class = "icon-tooltip")),
                   value = "FragmentQuantCorrected")
       ),
-      conditionalPanel(
-        condition = "input['app_template'] == 'protein_turnover'",
-        textInput(ns("diann_labeled_aa"),
-                  h5("SILAC-labeled amino acids", class = "icon-wrapper",
-                     icon("question-circle", lib = "font-awesome"),
-                     div("Comma-separated single-letter codes of SILAC-labeled amino acids (e.g. K for lysine, or K,R for lysine and arginine).", class = "icon-tooltip")),
-                  value = "K")
-      )
+      uiOutput(ns("diann_turnover_ui"))
     )
   )
 }


### PR DESCRIPTION
- **module-loadpage-ui.R**: Replaced the `conditionalPanel` (which kept the input alive in the DOM even when hidden) with a `uiOutput` placeholder — same as Spectronaut.
- **module-loadpage-server.R**: Added `output$diann_turnover_ui <- renderUI({...})` with `req(input$filetype == 'diann', input$DDA_DIA == 'LType')` and the template guard, so the input only exists when it's needed.
- **utils.R**: Reverted to the simple `!is.null()` check — now structurally identical to how the Spectronaut heavy labels are handled, and no longer needs to know about the template.

> **Recap:** Adding protein turnover support to MSstatsShiny. Just refactored the DIANN labeled amino acid input to use `renderUI` like Spectronaut, so it's `NULL` outside protein turnover mode. 