### PR TITLE
fix(loadpage): wrap top 6 rows of preview table in horizontal scrollbar

### DIFF
--- a/R/module-loadpage-server.R
+++ b/R/module-loadpage-server.R
@@ -606,14 +606,14 @@ loadpageServer <- function(id, parent_session, is_web_server = FALSE, app_templa
           tags$br(),
           conditionalPanel(condition = "input['loadpage-BIO'] !== 'PTM'",
                            h4("Top 6 rows of the dataset"),
-                           tableOutput(ns("summary"))
+                           div(style = "overflow-x: auto;", tableOutput(ns("summary")))
           ),
           conditionalPanel(condition = "input['loadpage-BIO'] == 'PTM'",
                            h4("Top 6 rows of the PTM dataset"),
-                           tableOutput(ns("summary_ptm")),
+                           div(style = "overflow-x: auto;", tableOutput(ns("summary_ptm"))),
                            tags$br(),
                            h4("Top 6 rows of the unmodified protein dataset"),
-                           tableOutput(ns("summary_prot"))
+                           div(style = "overflow-x: auto;", tableOutput(ns("summary_prot")))
           )
         )
       })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

When displaying the top 6 rows of preview tables during data upload, tables that contain many columns can exceed the width of their container, causing horizontal overflow and poor user experience. This PR addresses the issue by enabling horizontal scrolling for these preview tables, allowing users to view all columns without horizontal page overflow affecting the page layout.

## Changes

- **Wrapped preview table outputs with horizontal scrollbar containers**: Three preview tables (`summary`, `summary_ptm`, `summary_prot`) are now wrapped in `div` elements with `style = "overflow-x: auto;"` CSS applied
  - Line 609: Non-PTM dataset preview table (`summary`)
  - Line 613: PTM dataset preview table (`summary_ptm`)
  - Line 616: Unmodified protein dataset preview table (`summary_prot`)
- The underlying table rendering logic and data sources remain unchanged; only the container styling is modified
- Change applies to the summary tables UI rendered within the `summary_tables` reactive output in the loadpage server module

## Unit Tests

No unit tests were added or modified. The existing test suite in `tests/testthat/test-module-loadpage-ui.R` covers UI structure validation but does not include specific tests for the server-side rendering of preview tables or their container styling.

## Coding Guidelines

The changes follow the project's established patterns and do not introduce any violations of the coding guidelines documented in `.github/CONTRIBUTING.md`. The modification uses standard Shiny tag manipulation with CSS styling consistent with the codebase's approach to layout management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->