### PR TITLE
fix(network-viz): Fix deletion logic with protein complex edges

### DIFF
--- a/R/module-visualize-network-server.R
+++ b/R/module-visualize-network-server.R
@@ -707,14 +707,32 @@ visualizeNetworkServer <- function(id, parent_session, dataComparison) {
   # Observe edge deletion events from the visualization
   observeEvent(input$network_edge_deleted, {
     edge_data <- input$network_edge_deleted
-    deletedEdges(c(deletedEdges(), list(edge_data)))
 
+    new_deletions <- list(edge_data)
     updated_edges <- MSstatsBioNet::deleteEdgeFromNetwork(
       currentEdgesTable(),
       edge_data$source,
       edge_data$target,
       edge_data$interaction
     )
+
+    # Complex edges are stored bidirectionally, so also remove the reverse direction
+    if (identical(edge_data$interaction, "Complex")) {
+      reverse_edge_data <- list(
+        source = edge_data$target,
+        target = edge_data$source,
+        interaction = edge_data$interaction
+      )
+      new_deletions <- c(new_deletions, list(reverse_edge_data))
+      updated_edges <- MSstatsBioNet::deleteEdgeFromNetwork(
+        updated_edges,
+        edge_data$target,
+        edge_data$source,
+        edge_data$interaction
+      )
+    }
+
+    deletedEdges(c(deletedEdges(), new_deletions))
     currentEdgesTable(updated_edges)
 
     output$edgesTable <- DT::renderDT({


### PR DESCRIPTION
## Motivation and Context

When deleting protein complex edges, we need to account that they are bidirectional / undirected, so deleting one direction should delete the other direction.