### PR TITLE
fix(ptm-tests): Fix unit tests for PTM differential analysis

### DIFF
--- a/tests/testthat/test-utils-statmodel-server.R
+++ b/tests/testthat/test-utils-statmodel-server.R
@@ -287,7 +287,7 @@ test_that("extract_significant_proteins filters PTM data correctly", {
   loadpage_input <- list(BIO = "PTM")
   
   result <- extract_significant_proteins(data_comp, loadpage_input, 0.05)
-  expect_equal(nrow(result), 1)
+  expect_equal(nrow(result$ADJUSTED.Model), 1)
 })
 
 test_that("extract_significant_proteins filters TMT data correctly", {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

PTM (post-translational modification) differential analysis in MSstatsShiny uses a specialized data structure that differs from standard protein analysis. When analyzing PTM data, the `extract_significant_proteins` function returns a list containing three separate data frames: `PTM.Model`, `PROTEIN.Model`, and `ADJUSTED.Model` (the adjusted PTM results accounting for protein-level abundance). 

The issue was that unit tests for PTM differential analysis were incorrectly validating the overall structure of the returned object rather than the expected number of significant rows within the `ADJUSTED.Model` data frame specifically. This misalignment between the test assertion and the actual function behavior prevented accurate verification of PTM result filtering.

## Changes Made

- **Test Assertion Fix**: Updated the PTM test in `test-utils-statmodel-server.R` to validate `nrow(result$ADJUSTED.Model)` instead of `nrow(result)`. The corrected test now properly checks that filtering by adjusted p-value threshold produces exactly 1 significant protein (out of 2 proteins in ADJUSTED.Model where only P1 with p-value 0.04 falls below the 0.05 threshold).

## Unit Tests Added or Modified

**Modified**: `test-utils-statmodel-server.R` - Test case "extract_significant_proteins filters PTM data correctly"

The test validates that:
- Input data contains an `ADJUSTED.Model` data frame with 2 proteins
- Filtering with significance threshold of 0.05 correctly identifies 1 protein with adjusted p-value below threshold
- The corrected assertion `expect_equal(nrow(result$ADJUSTED.Model), 1)` now properly reflects the list-based return structure of the PTM-specific extraction function

<!-- end of auto-generated comment: release notes by coderabbit.ai -->