### PR TITLE
fix(MSstats+): Fix download analysis code

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -961,13 +961,30 @@ library(MSstatsPTM)\n", sep = "")
       codes = paste(codes, "data = data.table::fread(\"insert your MSstats scheme output from Spectronaut filepath\")\nannot_file = data.table::fread(\"insert your annotation filepath\")#Optional\n"
                     , sep = "")
 
-      codes = paste(codes, "data = SpectronauttoMSstatsFormat(data,
+      if (isTRUE(input$calculate_anomaly_scores)) {
+        codes = paste(codes, "run_order = data.table::fread(\"insert your run order CSV filepath (Run, Order columns)\")\n", sep = "")
+        codes = paste(codes, "data = SpectronauttoMSstatsFormat(data,
+                                       annotation = annot_file, #Optional
+                                       filter_with_Qvalue = ", input$q_val, ",
+                                       qvalue_cutoff = ", input$q_cutoff, ",
+                                       removeProtein_with1Feature = ", input$remove, ",
+                                       use_log_file = FALSE,
+                                       calculateAnomalyScores = TRUE,
+                                       runOrder = run_order,
+                                       anomalyModelFeatures = c(\"FG.ShapeQualityScore (MS2)\", \"FG.ShapeQualityScore (MS1)\", \"EGDeltaRT\"),
+                                       anomalyModelFeatureTemporal = c(\"mean_decrease\", \"mean_decrease\", \"dispersion_increase\"),
+                                       n_trees = 100,
+                                       max_depth = \"auto\",
+                                       numberOfCores = 1)\n", sep = "")
+      } else {
+        codes = paste(codes, "data = SpectronauttoMSstatsFormat(data,
                                        annotation = annot_file #Optional,
                                        filter_with_Qvalue = TRUE, ## same as default
                                        qvalue_cutoff = 0.01, ## same as default
                                        fewMeasurements=\"remove\",
                                        removeProtein_with1Feature = TRUE,
                                        use_log_file = FALSE)\n", sep = "")
+      }
     }
     else if(input$filetype == 'diann') {
       
@@ -1391,6 +1408,8 @@ preprocessDataCode <- function(qc_input,loadpage_input) {
       code_n_feat = 'NULL'
     }
 
+    sum_method = if (!is.null(qc_input$summaryMethod)) qc_input$summaryMethod else "TMP"
+
     codes = paste(codes, "\n# use MSstats for protein summarization\n", sep = "")
     codes = paste(codes, "summarized = MSstats::dataProcess(data,
                                normalization = \'", qc_input$norm,"\',\t\t\t\t
@@ -1398,7 +1417,7 @@ preprocessDataCode <- function(qc_input,loadpage_input) {
                                nameStandards = ", paste0("c('", paste(qc_input$names, collapse = "', '"), "')"), ",\t\t\t\t
                                featureSubset = \'", qc_input$features_used, "\',\t\t\t\t
                                n_top_feature = ", code_n_feat, ",\t\t\t\t
-                               summaryMethod=\"TMP\",
+                               summaryMethod=\"", sum_method, "\",
                                censoredInt=\'", qc_input$censInt, "\',\t\t\t\t
                                MBimpute=", qc_input$MBi, ",\t\t\t\t
                                remove50missing=", qc_input$remove50, ",\t\t\t\t
@@ -1411,6 +1430,14 @@ preprocessDataCode <- function(qc_input,loadpage_input) {
                            which.Protein = \"Enter Protein to Plot Here\",
                            summaryPlot = TRUE,
                            address = FALSE,isPlotly=TRUE)\n", sep="")
+
+    if (isTRUE(loadpage_input$calculate_anomaly_scores)) {
+      codes = paste(codes, "\n# Plot per-feature quality metrics (e.g. AnomalyScores) carried through from the converter\n", sep = "")
+      codes = paste(codes, "MSstats::MSstatsQualityMetricsPlot(data,
+                                       metric = \"AnomalyScores\",
+                                       which.Protein = \"Enter Protein to Plot Here\",
+                                       isPlotly = TRUE)\n", sep = "")
+    }
   }
 
   return(codes)

--- a/R/utils.R
+++ b/R/utils.R
@@ -978,11 +978,10 @@ library(MSstatsPTM)\n", sep = "")
                                        numberOfCores = 1)\n", sep = "")
       } else {
         codes = paste(codes, "data = SpectronauttoMSstatsFormat(data,
-                                       annotation = annot_file #Optional,
-                                       filter_with_Qvalue = TRUE, ## same as default
-                                       qvalue_cutoff = 0.01, ## same as default
-                                       fewMeasurements=\"remove\",
-                                       removeProtein_with1Feature = TRUE,
+                                       annotation = annot_file, #Optional
+                                       filter_with_Qvalue = ", input$q_val, ",
+                                       qvalue_cutoff = ", input$q_cutoff, ",
+                                       removeProtein_with1Feature = ", input$remove, ",
                                        use_log_file = FALSE)\n", sep = "")
       }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation and Context

This PR fixes generation of the R code users download from MSstatsShiny so it correctly supports Spectronaut anomaly-score computation and makes the protein summarization method configurable. Generated reproducible code now conditionally includes anomaly-score processing (loading run-order, anomaly-model parameters, parallel/core settings) when enabled, and uses the UI-selected summarization method instead of a hardcoded "TMP".

## Detailed Changes

- R/utils.R — getDataCode()
  - For Spectronaut filetype (`filetype == 'spec'`) the generated conversion call to SpectronauttoMSstatsFormat() is now conditional on `calculate_anomaly_scores`:
    - If true, generated code:
      - Loads a run-order CSV and assigns it to `run_order_path`.
      - Calls SpectronauttoMSstatsFormat(..., calculateAnomalyScores = TRUE, runOrder = run_order_path, anomalyModelFeatures = c("FG.ShapeQualityScore (MS2)", "FG.ShapeQualityScore (MS1)", "EGDeltaRT"), anomalyModelFeatureTemporal = c("mean_decrease", "mean_decrease", "dispersion_increase"), n_trees = 100, max_depth = "auto", numberOfCores = 1, ...)
    - If false, generated code retains the prior SpectronauttoMSstatsFormat() call without anomaly-score parameters.
- R/utils.R — preprocessDataCode()
  - summaryMethod is now derived from `qc_input$summaryMethod` with fallback to `"TMP"` instead of being hardcoded.
  - When `loadpage_input$calculate_anomaly_scores` is true, appended generated plotting code calls `MSstats::MSstatsQualityMetricsPlot()` for metric = "AnomalyScores" with `isPlotly = TRUE`.

- No exported function signatures were changed.

## Unit Tests

- tests/testthat/test-utils.R (updated/added):
  - Tests for getDataCode/getData generated output when anomaly scores enabled (mock_input_anomaly):
    - Asserts generated code includes `calculateAnomalyScores = TRUE`.
    - Asserts generated `runOrder` reference/path is present.
    - Asserts expected `anomalyModelFeatures` vector is present.
    - Asserts `n_trees` (100) is present.
  - Tests for getDataCode/getData when anomaly scores disabled (mock_input_no_anomaly):
    - Asserts anomaly-score-related parameters are not present in the generated output.
  - Note: preprocessDataCode() tests currently rely on stubbing getDataCode(); explicit assertions for the summaryMethod derivation and appended AnomalyScores plotting call are not deeply exercised in existing tests and may require additional unit tests to validate generated plotting code and summaryMethod propagation.

## Coding Guidelines Observations

- No public API or exported signatures changed.
- Code follows existing project style and uses isTRUE() for boolean checks.
- Generated-code construction uses nested paste()/string concatenation; readability could be improved by extracting helper builders or using templating, but this is a stylistic suggestion rather than a violation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vitek-Lab/MSstatsShiny/pull/209)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->