### PR TITLE
feat(spectronaut): Add annotation and run order uploads for large spectronaut uploads

### DIFF
--- a/R/module-loadpage-server.R
+++ b/R/module-loadpage-server.R
@@ -190,6 +190,30 @@ loadpageServer <- function(id, parent_session, is_web_server = FALSE, app_templa
       ui_elements
     })
     
+    # Spectronaut intensity column input — universal across both the
+    # regular (in-memory) and large-file paths, regardless of analysis
+    # template. Default tracks the template: turnover analyses want the
+    # MS1-only quantity, normal analyses want the normalized peak area
+    # (which is also `bigSpectronauttoMSstatsFormat`'s default).
+    output$spectronaut_intensity_ui <- renderUI({
+      req(input$filetype == 'spec', input$BIO != 'PTM')
+
+      default_intensity <- if (!is.null(app_template) &&
+                               app_template() == TEMPLATES$protein_turnover) {
+        "FG.MS1Quantity"
+      } else {
+        "F.NormalizedPeakArea"
+      }
+
+      textInput(session$ns("spec_intensity_col"),
+                label = h5("Intensity column",
+                           class = "icon-wrapper",
+                           icon("question-circle", lib = "font-awesome"),
+                           div("Spectronaut export column to use as the intensity measure (e.g. F.NormalizedPeakArea, F.PeakArea, FG.MS1Quantity). Leave at the default unless you have a specific reason to override it.",
+                               class = "icon-tooltip")),
+                value = default_intensity)
+    })
+
     output$spectronaut_turnover_ui <- renderUI({
       req(input$filetype == 'spec', input$BIO != 'PTM')
       req(!is.null(app_template) && app_template() == TEMPLATES$protein_turnover)
@@ -198,9 +222,6 @@ loadpageServer <- function(id, parent_session, is_web_server = FALSE, app_templa
       tagList(
         tags$hr(),
         h4("Protein Turnover Options"),
-        textInput(ns("spec_intensity_col"),
-                  "Intensity column",
-                  value = "FG.MS1Quantity"),
         textInput(ns("spec_peptide_seq_col"),
                   "Peptide sequence column",
                   value = "FG.LabeledSequence"),

--- a/R/module-loadpage-server.R
+++ b/R/module-loadpage-server.R
@@ -256,13 +256,13 @@ loadpageServer <- function(id, parent_session, is_web_server = FALSE, app_templa
         unique_peps_def <- if (is.null(input$filter_unique_peptides)) FALSE else input$filter_unique_peptides
         agg_psms_def <- if (is.null(input$aggregate_psms)) FALSE else input$aggregate_psms
         few_obs_def <- if (is.null(input$filter_few_obs)) FALSE else input$filter_few_obs
-        carry_anomaly_def <- if (is.null(input$carry_anomaly_features)) FALSE else input$carry_anomaly_features
+        calculate_anomaly_def <- if (is.null(input$calculate_anomaly_scores)) FALSE else input$calculate_anomaly_scores
 
         tagList(
           create_spectronaut_large_filter_options(session$ns, excluded_def, identified_def, qval_def),
           if (qval_def) create_spectronaut_qvalue_cutoff_ui(session$ns, cutoff_def),
           create_spectronaut_large_bottom_ui(session$ns, max_feature_def, unique_peps_def, agg_psms_def, few_obs_def),
-          create_spectronaut_large_annotation_ui(session$ns, carry_anomaly_def)
+          create_spectronaut_large_annotation_ui(session$ns, calculate_anomaly_def)
         )
       } else {
         NULL

--- a/R/module-loadpage-server.R
+++ b/R/module-loadpage-server.R
@@ -235,11 +235,13 @@ loadpageServer <- function(id, parent_session, is_web_server = FALSE, app_templa
         unique_peps_def <- if (is.null(input$filter_unique_peptides)) FALSE else input$filter_unique_peptides
         agg_psms_def <- if (is.null(input$aggregate_psms)) FALSE else input$aggregate_psms
         few_obs_def <- if (is.null(input$filter_few_obs)) FALSE else input$filter_few_obs
-        
+        carry_anomaly_def <- if (is.null(input$carry_anomaly_features)) FALSE else input$carry_anomaly_features
+
         tagList(
           create_spectronaut_large_filter_options(session$ns, excluded_def, identified_def, qval_def),
           if (qval_def) create_spectronaut_qvalue_cutoff_ui(session$ns, cutoff_def),
-          create_spectronaut_large_bottom_ui(session$ns, max_feature_def, unique_peps_def, agg_psms_def, few_obs_def)
+          create_spectronaut_large_bottom_ui(session$ns, max_feature_def, unique_peps_def, agg_psms_def, few_obs_def),
+          create_spectronaut_large_annotation_ui(session$ns, carry_anomaly_def)
         )
       } else {
         NULL

--- a/R/module-loadpage-ui.R
+++ b/R/module-loadpage-ui.R
@@ -342,6 +342,38 @@ create_spectronaut_large_bottom_ui <- function(ns, max_feature_def = 20, unique_
   )
 }
 
+#' Create Spectronaut large file annotation override + anomaly carry-through UI
+#'
+#' Renders an optional annotation upload that overrides Spectronaut's embedded
+#' R.Condition / R.Replicate columns on Run, and a checkbox that asks the
+#' converter to carry the anomaly-model feature columns
+#' (FG.ShapeQualityScore (MS2)/(MS1), EGDeltaRT) through the pipeline. The
+#' big-file converter does not fit the temporal anomaly RF (MSstatsBig
+#' provides no MSstatsAnomalyScores equivalent), so this is feature
+#' carry-through only — distinct from the regular-Spectronaut
+#' `calculate_anomaly_scores` checkbox which drives full model fitting.
+#' @noRd
+create_spectronaut_large_annotation_ui <- function(ns, carry_anomaly_def = FALSE) {
+  tagList(
+    tags$hr(),
+    h5("Annotation file (optional)",
+       class = "icon-wrapper",
+       icon("question-circle", lib = "font-awesome"),
+       div("Upload a CSV/TSV with columns Run, BioReplicate, Condition (and any extras). When supplied, the converter merges it on Run and overrides any Condition / BioReplicate values from Spectronaut's R.Condition / R.Replicate. Required for paired designs and other layouts Spectronaut's own annotation cannot express.",
+           class = "icon-tooltip")),
+    fileInput(ns("big_spec_annotation"), label = NULL,
+              multiple = FALSE, accept = c(".csv", ".tsv", ".txt")),
+    checkboxInput(ns("carry_anomaly_features"),
+                  label = tags$span(
+                    "Carry anomaly model features through pipeline",
+                    class = "icon-wrapper",
+                    icon("question-circle", lib = "font-awesome"),
+                    div("Preserves the FG.ShapeQualityScore (MS2)/(MS1) and EGDeltaRT columns on the converted output so downstream tools can use them. Note: unlike the regular Spectronaut path, the large-file converter does not fit the temporal anomaly model itself — it only carries the columns through.",
+                        class = "icon-tooltip")),
+                  value = carry_anomaly_def)
+  )
+}
+
 #' Create PTM FragPipe uploads
 #' @noRd
 create_ptm_fragpipe_uploads <- function(ns) {

--- a/R/module-loadpage-ui.R
+++ b/R/module-loadpage-ui.R
@@ -356,12 +356,18 @@ create_spectronaut_large_bottom_ui <- function(ns, max_feature_def = 20, unique_
 #'   (2) After `dplyr::collect`, `MSstatsConvert::MSstatsAnomalyScores`
 #'       is called on the in-memory result to fit the isolation-forest
 #'       model and produce the `AnomalyScores` column.
-#' The internal input ID `carry_anomaly_features` is named for step (1)
-#' but gates both steps; the user-facing label reflects step (2)'s outcome.
+#' Input IDs `calculate_anomaly_scores` and `run_order_file` are deliberately
+#' the same as the regular Spectronaut path's so downstream pages
+#' (module-qc-server's MSstats+ summarization gate, getDataCode's
+#' reproducibility script, etc.) read a single source of truth regardless
+#' of which path the user took. The two UI checkboxes never coexist —
+#' the regular path's `create_label_free_options` is hidden when
+#' `big_file_spec` is on, and this helper only renders when it is — so
+#' there is no Shiny namespace collision.
 #' A run-order CSV is required (Run + Order columns) — `MSstatsAnomalyScores`
 #' uses it for temporal feature engineering.
 #' @noRd
-create_spectronaut_large_annotation_ui <- function(ns, carry_anomaly_def = FALSE) {
+create_spectronaut_large_annotation_ui <- function(ns, calculate_anomaly_def = FALSE) {
   tagList(
     tags$hr(),
     h5("Annotation file (optional)",
@@ -371,17 +377,17 @@ create_spectronaut_large_annotation_ui <- function(ns, carry_anomaly_def = FALSE
            class = "icon-tooltip")),
     fileInput(ns("big_spec_annotation"), label = NULL,
               multiple = FALSE, accept = c(".csv", ".tsv", ".txt")),
-    checkboxInput(ns("carry_anomaly_features"),
+    checkboxInput(ns("calculate_anomaly_scores"),
                   label = tags$span(
                     "Calculate Anomaly Scores",
                     class = "icon-wrapper",
                     icon("question-circle", lib = "font-awesome"),
                     div("Runs the same anomaly scoring pipeline as the regular Spectronaut path: the converter carries FG.ShapeQualityScore (MS2)/(MS1) and EGDeltaRT through the out-of-memory steps, then MSstatsConvert::MSstatsAnomalyScores fits the isolation-forest model on the collected data and adds an AnomalyScores column. Requires a run order CSV.",
                         class = "icon-tooltip")),
-                  value = carry_anomaly_def),
+                  value = calculate_anomaly_def),
     conditionalPanel(
-      condition = sprintf("input['%s']", ns("carry_anomaly_features")),
-      fileInput(ns("big_run_order_file"),
+      condition = sprintf("input['%s']", ns("calculate_anomaly_scores")),
+      fileInput(ns("run_order_file"),
                 label = h5("Upload Run Order File",
                            class = "icon-wrapper",
                            icon("question-circle", lib = "font-awesome"),

--- a/R/module-loadpage-ui.R
+++ b/R/module-loadpage-ui.R
@@ -342,16 +342,23 @@ create_spectronaut_large_bottom_ui <- function(ns, max_feature_def = 20, unique_
   )
 }
 
-#' Create Spectronaut large file annotation override + anomaly carry-through UI
+#' Create Spectronaut large file annotation override + anomaly UI
 #'
 #' Renders an optional annotation upload that overrides Spectronaut's embedded
-#' R.Condition / R.Replicate columns on Run, and a checkbox that asks the
-#' converter to carry the anomaly-model feature columns
-#' (FG.ShapeQualityScore (MS2)/(MS1), EGDeltaRT) through the pipeline. The
-#' big-file converter does not fit the temporal anomaly RF (MSstatsBig
-#' provides no MSstatsAnomalyScores equivalent), so this is feature
-#' carry-through only — distinct from the regular-Spectronaut
-#' `calculate_anomaly_scores` checkbox which drives full model fitting.
+#' R.Condition / R.Replicate columns on Run, plus the "Calculate Anomaly
+#' Scores" controls. End-to-end anomaly scoring is a two-step pipeline in
+#' the large-file path:
+#'   (1) `bigSpectronauttoMSstatsFormat` runs with
+#'       `calculateAnomalyScores = TRUE` + the model feature column list,
+#'       which carries those feature columns through the out-of-memory
+#'       reduce/preprocess steps.
+#'   (2) After `dplyr::collect`, `MSstatsConvert::MSstatsAnomalyScores`
+#'       is called on the in-memory result to fit the isolation-forest
+#'       model and produce the `AnomalyScores` column.
+#' The internal input ID `carry_anomaly_features` is named for step (1)
+#' but gates both steps; the user-facing label reflects step (2)'s outcome.
+#' A run-order CSV is required (Run + Order columns) — `MSstatsAnomalyScores`
+#' uses it for temporal feature engineering.
 #' @noRd
 create_spectronaut_large_annotation_ui <- function(ns, carry_anomaly_def = FALSE) {
   tagList(
@@ -365,12 +372,22 @@ create_spectronaut_large_annotation_ui <- function(ns, carry_anomaly_def = FALSE
               multiple = FALSE, accept = c(".csv", ".tsv", ".txt")),
     checkboxInput(ns("carry_anomaly_features"),
                   label = tags$span(
-                    "Carry anomaly model features through pipeline",
+                    "Calculate Anomaly Scores",
                     class = "icon-wrapper",
                     icon("question-circle", lib = "font-awesome"),
-                    div("Preserves the FG.ShapeQualityScore (MS2)/(MS1) and EGDeltaRT columns on the converted output so downstream tools can use them. Note: unlike the regular Spectronaut path, the large-file converter does not fit the temporal anomaly model itself — it only carries the columns through.",
+                    div("Runs the same anomaly scoring pipeline as the regular Spectronaut path: the converter carries FG.ShapeQualityScore (MS2)/(MS1) and EGDeltaRT through the out-of-memory steps, then MSstatsConvert::MSstatsAnomalyScores fits the isolation-forest model on the collected data and adds an AnomalyScores column. Requires a run order CSV.",
                         class = "icon-tooltip")),
-                  value = carry_anomaly_def)
+                  value = carry_anomaly_def),
+    conditionalPanel(
+      condition = sprintf("input['%s']", ns("carry_anomaly_features")),
+      fileInput(ns("big_run_order_file"),
+                label = h5("Upload Run Order File",
+                           class = "icon-wrapper",
+                           icon("question-circle", lib = "font-awesome"),
+                           div("CSV with two columns: 'Run' (sequence name matching the converter output) and 'Order' (chronological run number, e.g. 1, 2, 3...).",
+                               class = "icon-tooltip")),
+                multiple = FALSE, accept = c(".csv"))
+    )
   )
 }
 

--- a/R/module-loadpage-ui.R
+++ b/R/module-loadpage-ui.R
@@ -282,6 +282,7 @@ create_spectronaut_uploads <- function(ns) {
     uiOutput(ns("spectronaut_header_ui")),
     uiOutput(ns("spectronaut_file_selection_ui")),
     uiOutput(ns("spectronaut_options_ui")),
+    uiOutput(ns("spectronaut_intensity_ui")),
     uiOutput(ns("spectronaut_turnover_ui"))
   )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -692,7 +692,33 @@ getData <- function(input) {
           shinybusy::remove_modal_spinner()
           return(NULL)
         }
-        
+
+        # Step 2 of the anomaly scoring pipeline: the converter only
+        # carries the model feature columns through the out-of-memory
+        # steps; MSstatsAnomalyScores fits the isolation-forest model
+        # on the in-memory result and adds the AnomalyScores column.
+        # Defaults mirror SpectronauttoMSstatsFormat's regular path
+        # (missing_run_count = 0.5, n_feat = 100, n_trees = 100,
+        # max_depth = "auto", cores = 1).
+        if (isTRUE(input$carry_anomaly_features) &&
+            !is.null(input$big_run_order_file)) {
+          run_order <- data.table::fread(input$big_run_order_file$datapath)
+          mydata <- MSstatsConvert::MSstatsAnomalyScores(
+            input = mydata,
+            quality_metrics = c("FG.ShapeQualityScore (MS2)",
+                                "FG.ShapeQualityScore (MS1)",
+                                "EGDeltaRT"),
+            temporal_direction = c("mean_decrease",
+                                   "mean_decrease",
+                                   "dispersion_increase"),
+            missing_run_count = 0.5,
+            n_feat = 100,
+            run_order = run_order,
+            n_trees = 100,
+            max_depth = "auto",
+            cores = 1)
+        }
+
       } else {
         data = data.table::fread(input$specdata$datapath)
         # Base arguments for the Spectronaut converter
@@ -1012,6 +1038,25 @@ library(MSstatsPTM)\n", sep = "")
                       big_spec_extra,
                       ")\ndata = dplyr::collect(converted)\n",
                       sep = "")
+
+        if (isTRUE(input$carry_anomaly_features)) {
+          codes = paste(codes,
+                        "# Step 2 of the anomaly scoring pipeline: fit the\n",
+                        "# isolation-forest model on the collected data and\n",
+                        "# add an AnomalyScores column.\n",
+                        "run_order = data.table::fread(\"insert your run order CSV filepath (Run, Order columns)\")\n",
+                        "data = MSstatsConvert::MSstatsAnomalyScores(\n",
+                        "  input = data,\n",
+                        "  quality_metrics = c(\"FG.ShapeQualityScore (MS2)\", \"FG.ShapeQualityScore (MS1)\", \"EGDeltaRT\"),\n",
+                        "  temporal_direction = c(\"mean_decrease\", \"mean_decrease\", \"dispersion_increase\"),\n",
+                        "  missing_run_count = 0.5,\n",
+                        "  n_feat = 100,\n",
+                        "  run_order = run_order,\n",
+                        "  n_trees = 100,\n",
+                        "  max_depth = \"auto\",\n",
+                        "  cores = 1)\n",
+                        sep = "")
+        }
 
       } else {
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -641,9 +641,12 @@ getData <- function(input) {
         }
         
         shinybusy::update_modal_spinner(text = "Processing large Spectronaut file...")
-        
-        # Call the big file conversion function from MSstatsConvert
-        converted_data <- MSstatsBig::bigSpectronauttoMSstatsFormat(
+
+        # Base arguments shared by every large-file Spectronaut run.
+        # Optional args (annotation override, anomaly-feature
+        # carry-through) are spliced in below so callers that don't
+        # supply them aren't forced to pass NULL / FALSE explicitly.
+        big_spec_args <- list(
           input_file = local_big_file_path,
           output_file_name = "output_file.csv",
           backend = "arrow",
@@ -656,6 +659,22 @@ getData <- function(input) {
           aggregate_psms = input$aggregate_psms,
           filter_few_obs = input$filter_few_obs
         )
+
+        if (!is.null(input$big_spec_annotation)) {
+          big_spec_args$annotation <- data.table::fread(
+            input$big_spec_annotation$datapath)
+        }
+
+        if (isTRUE(input$carry_anomaly_features)) {
+          big_spec_args$calculateAnomalyScores <- TRUE
+          big_spec_args$anomalyModelFeatures <- c(
+            "FG.ShapeQualityScore (MS2)",
+            "FG.ShapeQualityScore (MS1)",
+            "EGDeltaRT")
+        }
+
+        converted_data <- do.call(
+          MSstatsBig::bigSpectronauttoMSstatsFormat, big_spec_args)
         
         # Attempt to load the data into memory. 
         mydata <- tryCatch({
@@ -958,6 +977,44 @@ library(MSstatsPTM)\n", sep = "")
     }
     else if(input$filetype == 'spec') {
 
+      if (isTRUE(input$big_file_spec)) {
+        codes = paste(codes,
+                      "# Large-file (out-of-memory) Spectronaut path.\n",
+                      "input_file = \"insert your raw Spectronaut export filepath\"\n",
+                      sep = "")
+
+        big_spec_extra <- ""
+        if (!is.null(input$big_spec_annotation)) {
+          codes = paste(codes,
+                        "annot_file = data.table::fread(\"insert your annotation filepath (Run, BioReplicate, Condition)\")\n",
+                        sep = "")
+          big_spec_extra <- paste0(big_spec_extra,
+                                   ",\n                                          annotation = annot_file")
+        }
+        if (isTRUE(input$carry_anomaly_features)) {
+          big_spec_extra <- paste0(big_spec_extra,
+                                   ",\n                                          calculateAnomalyScores = TRUE",
+                                   ",\n                                          anomalyModelFeatures = c(\"FG.ShapeQualityScore (MS2)\", \"FG.ShapeQualityScore (MS1)\", \"EGDeltaRT\")")
+        }
+
+        codes = paste(codes,
+                      "converted = MSstatsBig::bigSpectronauttoMSstatsFormat(input_file,
+                                          output_file_name = \"output_file.csv\",
+                                          backend = \"arrow\",
+                                          filter_by_excluded = ", input$filter_by_excluded, ",
+                                          filter_by_identified = ", input$filter_by_identified, ",
+                                          filter_by_qvalue = ", input$filter_by_qvalue, ",
+                                          qvalue_cutoff = ", input$qvalue_cutoff, ",
+                                          max_feature_count = ", input$max_feature_count, ",
+                                          filter_unique_peptides = ", input$filter_unique_peptides, ",
+                                          aggregate_psms = ", input$aggregate_psms, ",
+                                          filter_few_obs = ", input$filter_few_obs,
+                      big_spec_extra,
+                      ")\ndata = dplyr::collect(converted)\n",
+                      sep = "")
+
+      } else {
+
       codes = paste(codes, "data = data.table::fread(\"insert your MSstats scheme output from Spectronaut filepath\")\nannot_file = data.table::fread(\"insert your annotation filepath\")#Optional\n"
                     , sep = "")
 
@@ -983,6 +1040,8 @@ library(MSstatsPTM)\n", sep = "")
                                        qvalue_cutoff = ", input$q_cutoff, ",
                                        removeProtein_with1Feature = ", input$remove, ",
                                        use_log_file = FALSE)\n", sep = "")
+      }
+
       }
     }
     else if(input$filetype == 'diann') {

--- a/R/utils.R
+++ b/R/utils.R
@@ -670,7 +670,7 @@ getData <- function(input) {
             input$big_spec_annotation$datapath)
         }
 
-        if (isTRUE(input$carry_anomaly_features)) {
+        if (isTRUE(input$calculate_anomaly_scores)) {
           big_spec_args$calculateAnomalyScores <- TRUE
           big_spec_args$anomalyModelFeatures <- c(
             "FG.ShapeQualityScore (MS2)",
@@ -698,9 +698,9 @@ getData <- function(input) {
           return(NULL)
         }
 
-        if (isTRUE(input$carry_anomaly_features) &&
-            !is.null(input$big_run_order_file)) {
-          run_order <- data.table::fread(input$big_run_order_file$datapath)
+        if (isTRUE(input$calculate_anomaly_scores) &&
+            !is.null(input$run_order_file)) {
+          run_order <- data.table::fread(input$run_order_file$datapath)
           mydata <- MSstatsConvert::MSstatsAnomalyScores(
             input = mydata,
             quality_metrics = c("FGShapeQualityScore(MS2)",
@@ -1021,7 +1021,7 @@ library(MSstatsPTM)\n", sep = "")
           big_spec_extra <- paste0(big_spec_extra,
                                    ",\n                                          annotation = annot_file")
         }
-        if (isTRUE(input$carry_anomaly_features)) {
+        if (isTRUE(input$calculate_anomaly_scores)) {
           big_spec_extra <- paste0(big_spec_extra,
                                    ",\n                                          calculateAnomalyScores = TRUE",
                                    ",\n                                          anomalyModelFeatures = c(\"FG.ShapeQualityScore (MS2)\", \"FG.ShapeQualityScore (MS1)\", \"EG.DeltaRT\")")
@@ -1043,7 +1043,7 @@ library(MSstatsPTM)\n", sep = "")
                       ")\ndata = dplyr::collect(converted)\n",
                       sep = "")
 
-        if (isTRUE(input$carry_anomaly_features)) {
+        if (isTRUE(input$calculate_anomaly_scores)) {
           codes = paste(codes,
                         "# Step 2 of the anomaly scoring pipeline: fit the\n",
                         "# isolation-forest model on the collected data and\n",

--- a/R/utils.R
+++ b/R/utils.R
@@ -727,6 +727,15 @@ getData <- function(input) {
         }
 
       } else {
+
+        if (isTRUE(input$calculate_anomaly_scores) && is.null(input$run_order_file)) {
+          showNotification(
+            "Error: Run Order CSV is required when Calculate Anomaly Scores is enabled. Please upload a CSV with Run and Order columns.",
+            type = "error",
+            duration = NULL)
+          return(NULL)
+        }
+
         data = data.table::fread(input$specdata$datapath)
         # Base arguments for the Spectronaut converter
         converter_args = list(

--- a/R/utils.R
+++ b/R/utils.R
@@ -733,6 +733,7 @@ getData <- function(input) {
             "Error: Run Order CSV is required when Calculate Anomaly Scores is enabled. Please upload a CSV with Run and Order columns.",
             type = "error",
             duration = NULL)
+          remove_modal_spinner()
           return(NULL)
         }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -639,7 +639,16 @@ getData <- function(input) {
           shinybusy::remove_modal_spinner()
           return(NULL)
         }
-        
+
+        if (isTRUE(input$calculate_anomaly_scores) && is.null(input$run_order_file)) {
+          showNotification(
+            "Error: Run Order CSV is required when Calculate Anomaly Scores is enabled. Please upload a CSV with Run and Order columns.",
+            type = "error",
+            duration = NULL)
+          shinybusy::remove_modal_spinner()
+          return(NULL)
+        }
+
         shinybusy::update_modal_spinner(text = "Processing large Spectronaut file...")
 
         # Base arguments shared by every large-file Spectronaut run.

--- a/R/utils.R
+++ b/R/utils.R
@@ -660,6 +660,11 @@ getData <- function(input) {
           filter_few_obs = input$filter_few_obs
         )
 
+        if (!is.null(input$spec_intensity_col) &&
+            nchar(trimws(input$spec_intensity_col)) > 0) {
+          big_spec_args$intensity <- trimws(input$spec_intensity_col)
+        }
+
         if (!is.null(input$big_spec_annotation)) {
           big_spec_args$annotation <- data.table::fread(
             input$big_spec_annotation$datapath)
@@ -670,7 +675,7 @@ getData <- function(input) {
           big_spec_args$anomalyModelFeatures <- c(
             "FG.ShapeQualityScore (MS2)",
             "FG.ShapeQualityScore (MS1)",
-            "EGDeltaRT")
+            "EG.DeltaRT")
         }
 
         converted_data <- do.call(
@@ -693,20 +698,13 @@ getData <- function(input) {
           return(NULL)
         }
 
-        # Step 2 of the anomaly scoring pipeline: the converter only
-        # carries the model feature columns through the out-of-memory
-        # steps; MSstatsAnomalyScores fits the isolation-forest model
-        # on the in-memory result and adds the AnomalyScores column.
-        # Defaults mirror SpectronauttoMSstatsFormat's regular path
-        # (missing_run_count = 0.5, n_feat = 100, n_trees = 100,
-        # max_depth = "auto", cores = 1).
         if (isTRUE(input$carry_anomaly_features) &&
             !is.null(input$big_run_order_file)) {
           run_order <- data.table::fread(input$big_run_order_file$datapath)
           mydata <- MSstatsConvert::MSstatsAnomalyScores(
             input = mydata,
-            quality_metrics = c("FG.ShapeQualityScore (MS2)",
-                                "FG.ShapeQualityScore (MS1)",
+            quality_metrics = c("FGShapeQualityScore(MS2)",
+                                "FGShapeQualityScore(MS1)",
                                 "EGDeltaRT"),
             temporal_direction = c("mean_decrease",
                                    "mean_decrease",
@@ -1010,6 +1008,12 @@ library(MSstatsPTM)\n", sep = "")
                       sep = "")
 
         big_spec_extra <- ""
+        if (!is.null(input$spec_intensity_col) &&
+            nchar(trimws(input$spec_intensity_col)) > 0) {
+          big_spec_extra <- paste0(big_spec_extra,
+                                   ",\n                                          intensity = \"",
+                                   trimws(input$spec_intensity_col), "\"")
+        }
         if (!is.null(input$big_spec_annotation)) {
           codes = paste(codes,
                         "annot_file = data.table::fread(\"insert your annotation filepath (Run, BioReplicate, Condition)\")\n",
@@ -1020,7 +1024,7 @@ library(MSstatsPTM)\n", sep = "")
         if (isTRUE(input$carry_anomaly_features)) {
           big_spec_extra <- paste0(big_spec_extra,
                                    ",\n                                          calculateAnomalyScores = TRUE",
-                                   ",\n                                          anomalyModelFeatures = c(\"FG.ShapeQualityScore (MS2)\", \"FG.ShapeQualityScore (MS1)\", \"EGDeltaRT\")")
+                                   ",\n                                          anomalyModelFeatures = c(\"FG.ShapeQualityScore (MS2)\", \"FG.ShapeQualityScore (MS1)\", \"EG.DeltaRT\")")
         }
 
         codes = paste(codes,
@@ -1047,7 +1051,9 @@ library(MSstatsPTM)\n", sep = "")
                         "run_order = data.table::fread(\"insert your run order CSV filepath (Run, Order columns)\")\n",
                         "data = MSstatsConvert::MSstatsAnomalyScores(\n",
                         "  input = data,\n",
-                        "  quality_metrics = c(\"FG.ShapeQualityScore (MS2)\", \"FG.ShapeQualityScore (MS1)\", \"EGDeltaRT\"),\n",
+                        "  # Standardized column names (raw Spectronaut names\n",
+                        "  # had `.` and ` ` stripped during the converter step).\n",
+                        "  quality_metrics = c(\"FGShapeQualityScore(MS2)\", \"FGShapeQualityScore(MS1)\", \"EGDeltaRT\"),\n",
                         "  temporal_direction = c(\"mean_decrease\", \"mean_decrease\", \"dispersion_increase\"),\n",
                         "  missing_run_count = 0.5,\n",
                         "  n_feat = 100,\n",
@@ -1063,11 +1069,19 @@ library(MSstatsPTM)\n", sep = "")
       codes = paste(codes, "data = data.table::fread(\"insert your MSstats scheme output from Spectronaut filepath\")\nannot_file = data.table::fread(\"insert your annotation filepath\")#Optional\n"
                     , sep = "")
 
+      reg_spec_intensity_arg <- if (!is.null(input$spec_intensity_col) &&
+                                    nchar(trimws(input$spec_intensity_col)) > 0) {
+        paste0("                                       intensity = \"",
+               trimws(input$spec_intensity_col), "\",\n")
+      } else {
+        ""
+      }
+
       if (isTRUE(input$calculate_anomaly_scores)) {
         codes = paste(codes, "run_order = data.table::fread(\"insert your run order CSV filepath (Run, Order columns)\")\n", sep = "")
         codes = paste(codes, "data = SpectronauttoMSstatsFormat(data,
                                        annotation = annot_file, #Optional
-                                       filter_with_Qvalue = ", input$q_val, ",
+", reg_spec_intensity_arg, "                                       filter_with_Qvalue = ", input$q_val, ",
                                        qvalue_cutoff = ", input$q_cutoff, ",
                                        removeProtein_with1Feature = ", input$remove, ",
                                        use_log_file = FALSE,
@@ -1081,7 +1095,7 @@ library(MSstatsPTM)\n", sep = "")
       } else {
         codes = paste(codes, "data = SpectronauttoMSstatsFormat(data,
                                        annotation = annot_file, #Optional
-                                       filter_with_Qvalue = ", input$q_val, ",
+", reg_spec_intensity_arg, "                                       filter_with_Qvalue = ", input$q_val, ",
                                        qvalue_cutoff = ", input$q_cutoff, ",
                                        removeProtein_with1Feature = ", input$remove, ",
                                        use_log_file = FALSE)\n", sep = "")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1710,7 +1710,7 @@ describe("getData for Big Spectronaut", {
     expect_equal(captured_scoring_args$cores, 1)
   })
 
-  test_that("does NOT call MSstatsAnomalyScores when calculate_anomaly_scores is TRUE but run_order_file is missing", {
+  test_that("fails fast when calculate_anomaly_scores is TRUE but run_order_file is missing", {
     input_no_runorder <- mock_input_big
     input_no_runorder$calculate_anomaly_scores <- TRUE
     input_no_runorder$run_order_file <- NULL
@@ -1718,23 +1718,15 @@ describe("getData for Big Spectronaut", {
     stub(getData, "shinyFiles::getVolumes", function() function() c(root = "/"))
     stub(getData, "shinyFiles::parseFilePaths", function(...) data.frame(datapath = "test.csv"))
     stub(getData, "file.exists", TRUE)
-    stub(getData, "shinybusy::update_modal_spinner", function(...) NULL)
     stub(getData, "shinybusy::remove_modal_spinner", function(...) NULL)
-    stub(getData, "showNotification", function(...) NULL)
-    stub(getData, "MSstatsBig::bigSpectronauttoMSstatsFormat",
-         mock_arrow_obj)
-    stub(getData, "dplyr::collect", mock_df)
+    stub(getData, "showNotification",
+         function(msg, ...) expect_match(msg, "Run Order CSV"))
+    # The converter should never run; if it does, fail the test.
+    stub(getData, "shinybusy::update_modal_spinner",
+         function(...) stop("converter step reached despite missing run order"))
 
-    scoring_called <- FALSE
-    stub(getData, "MSstatsConvert::MSstatsAnomalyScores",
-         function(...) {
-           scoring_called <<- TRUE
-           mock_df
-         })
-
-    getData(input_no_runorder)
-
-    expect_false(scoring_called)
+    res <- getData(input_no_runorder)
+    expect_null(res)
   })
 
   test_that("passes intensity to converter when spec_intensity_col is set", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1650,10 +1650,12 @@ describe("getData for Big Spectronaut", {
     getData(input_with_anomaly)
 
     expect_true(isTRUE(captured_args$calculateAnomalyScores))
+    # Raw Spectronaut export names — the converter applies
+    # .standardizeColnames internally on the way out.
     expect_equal(captured_args$anomalyModelFeatures,
                  c("FG.ShapeQualityScore (MS2)",
                    "FG.ShapeQualityScore (MS1)",
-                   "EGDeltaRT"))
+                   "EG.DeltaRT"))
     # The big-file converter itself does NOT take a runOrder arg —
     # that's consumed by the separate MSstatsAnomalyScores step
     # post-collect (covered in the next test).
@@ -1691,9 +1693,12 @@ describe("getData for Big Spectronaut", {
 
     expect_false(is.null(captured_scoring_args))
     expect_equal(captured_scoring_args$input, mock_df)
+    # Standardized column names — the in-memory data after collect
+    # has had .standardizeColnames applied during the converter
+    # step, so MSstatsAnomalyScores must look for these names.
     expect_equal(captured_scoring_args$quality_metrics,
-                 c("FG.ShapeQualityScore (MS2)",
-                   "FG.ShapeQualityScore (MS1)",
+                 c("FGShapeQualityScore(MS2)",
+                   "FGShapeQualityScore(MS1)",
                    "EGDeltaRT"))
     expect_equal(captured_scoring_args$temporal_direction,
                  c("mean_decrease",
@@ -1730,6 +1735,29 @@ describe("getData for Big Spectronaut", {
     getData(input_no_runorder)
 
     expect_false(scoring_called)
+  })
+
+  test_that("passes intensity to converter when spec_intensity_col is set", {
+    input_with_intensity <- mock_input_big
+    input_with_intensity$spec_intensity_col <- "FG.MS1Quantity"
+
+    stub(getData, "shinyFiles::getVolumes", function() function() c(root = "/"))
+    stub(getData, "shinyFiles::parseFilePaths", function(...) data.frame(datapath = "test.csv"))
+    stub(getData, "file.exists", TRUE)
+    stub(getData, "shinybusy::update_modal_spinner", function(...) NULL)
+    stub(getData, "shinybusy::remove_modal_spinner", function(...) NULL)
+    stub(getData, "showNotification", function(...) NULL)
+    stub(getData, "MSstatsBig::bigSpectronauttoMSstatsFormat",
+         mock_big_spec_converter)
+    captured_args <- NULL
+    stub(getData, "dplyr::collect", function(x) {
+      captured_args <<- x
+      mock_df
+    })
+
+    getData(input_with_intensity)
+
+    expect_equal(captured_args$intensity, "FG.MS1Quantity")
   })
 
   test_that("omits annotation + anomaly args when neither is supplied", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1485,11 +1485,37 @@ describe("getData for Spectronaut input with anomaly scores", {
     
     #EXECUTION
     result_args <- getData(mock_input_no_anomaly)
-    
+
     #ASSERTION: Check that the anomaly arguments are NOT present
     expect_null(result_args$calculateAnomalyScores)
     expect_null(result_args$runOrder)
     expect_null(result_args$anomalyModelFeatures)
+  })
+
+  test_that("fails fast when calculate_anomaly_scores is TRUE but run_order_file is missing (regular path)", {
+    mock_input_missing_runorder <- list(
+      BIO = "Protein",
+      DDA_DIA = "DIA",
+      filetype = "spec",
+      specdata = list(datapath = "dummy_spec.csv"),
+      annot = list(datapath = "dummy_annot.csv"),
+      q_val = TRUE,
+      q_cutoff = 0.01,
+      remove = TRUE,
+      calculate_anomaly_scores = TRUE,
+      run_order_file = NULL
+    )
+
+    stub(getData, "showNotification",
+         function(msg, ...) expect_match(msg, "Run Order CSV"))
+    # The converter should never run; if it does, fail the test.
+    stub(getData, "data.table::fread",
+         function(...) stop("fread reached despite missing run order"))
+    stub(getData, "SpectronauttoMSstatsFormat",
+         function(...) stop("converter reached despite missing run order"))
+
+    res <- getData(mock_input_missing_runorder)
+    expect_null(res)
   })
 })
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1622,9 +1622,10 @@ describe("getData for Big Spectronaut", {
     expect_equal(captured_args$annotation, dummy_annot_df)
   })
 
-  test_that("passes calculateAnomalyScores + anomalyModelFeatures when carry_anomaly_features = TRUE", {
+  test_that("passes calculateAnomalyScores + anomalyModelFeatures to converter when carry_anomaly_features = TRUE", {
     input_with_anomaly <- mock_input_big
     input_with_anomaly$carry_anomaly_features <- TRUE
+    input_with_anomaly$big_run_order_file <- list(datapath = "run_order.csv")
 
     stub(getData, "shinyFiles::getVolumes", function() function() c(root = "/"))
     stub(getData, "shinyFiles::parseFilePaths", function(...) data.frame(datapath = "test.csv"))
@@ -1639,6 +1640,12 @@ describe("getData for Big Spectronaut", {
       captured_args <<- x
       mock_df
     })
+    # Skip the post-collect scoring call for this test — it's
+    # exercised separately below.
+    stub(getData, "data.table::fread",
+         data.frame(Run = "run1", Order = 1L))
+    stub(getData, "MSstatsConvert::MSstatsAnomalyScores",
+         function(...) mock_df)
 
     getData(input_with_anomaly)
 
@@ -1647,9 +1654,82 @@ describe("getData for Big Spectronaut", {
                  c("FG.ShapeQualityScore (MS2)",
                    "FG.ShapeQualityScore (MS1)",
                    "EGDeltaRT"))
-    # No runOrder for the big-file path — the converter doesn't
-    # accept one (MSstatsBig has no MSstatsAnomalyScores call).
+    # The big-file converter itself does NOT take a runOrder arg —
+    # that's consumed by the separate MSstatsAnomalyScores step
+    # post-collect (covered in the next test).
     expect_null(captured_args$runOrder)
+  })
+
+  test_that("calls MSstatsConvert::MSstatsAnomalyScores after collect when carry_anomaly_features && big_run_order_file are set", {
+    input_with_full_anomaly <- mock_input_big
+    input_with_full_anomaly$carry_anomaly_features <- TRUE
+    input_with_full_anomaly$big_run_order_file <- list(datapath = "run_order.csv")
+
+    stub(getData, "shinyFiles::getVolumes", function() function() c(root = "/"))
+    stub(getData, "shinyFiles::parseFilePaths", function(...) data.frame(datapath = "test.csv"))
+    stub(getData, "file.exists", TRUE)
+    stub(getData, "shinybusy::update_modal_spinner", function(...) NULL)
+    stub(getData, "shinybusy::remove_modal_spinner", function(...) NULL)
+    stub(getData, "showNotification", function(...) NULL)
+    stub(getData, "MSstatsBig::bigSpectronauttoMSstatsFormat",
+         mock_arrow_obj)
+    stub(getData, "dplyr::collect", mock_df)
+
+    run_order_df <- data.frame(Run = c("run1", "run2"),
+                               Order = c(1L, 2L),
+                               stringsAsFactors = FALSE)
+    stub(getData, "data.table::fread", run_order_df)
+
+    captured_scoring_args <- NULL
+    stub(getData, "MSstatsConvert::MSstatsAnomalyScores",
+         function(...) {
+           captured_scoring_args <<- list(...)
+           mock_df
+         })
+
+    getData(input_with_full_anomaly)
+
+    expect_false(is.null(captured_scoring_args))
+    expect_equal(captured_scoring_args$input, mock_df)
+    expect_equal(captured_scoring_args$quality_metrics,
+                 c("FG.ShapeQualityScore (MS2)",
+                   "FG.ShapeQualityScore (MS1)",
+                   "EGDeltaRT"))
+    expect_equal(captured_scoring_args$temporal_direction,
+                 c("mean_decrease",
+                   "mean_decrease",
+                   "dispersion_increase"))
+    expect_equal(captured_scoring_args$run_order, run_order_df)
+    expect_equal(captured_scoring_args$n_trees, 100)
+    expect_equal(captured_scoring_args$max_depth, "auto")
+    expect_equal(captured_scoring_args$cores, 1)
+  })
+
+  test_that("does NOT call MSstatsAnomalyScores when carry_anomaly_features is TRUE but big_run_order_file is missing", {
+    input_no_runorder <- mock_input_big
+    input_no_runorder$carry_anomaly_features <- TRUE
+    input_no_runorder$big_run_order_file <- NULL
+
+    stub(getData, "shinyFiles::getVolumes", function() function() c(root = "/"))
+    stub(getData, "shinyFiles::parseFilePaths", function(...) data.frame(datapath = "test.csv"))
+    stub(getData, "file.exists", TRUE)
+    stub(getData, "shinybusy::update_modal_spinner", function(...) NULL)
+    stub(getData, "shinybusy::remove_modal_spinner", function(...) NULL)
+    stub(getData, "showNotification", function(...) NULL)
+    stub(getData, "MSstatsBig::bigSpectronauttoMSstatsFormat",
+         mock_arrow_obj)
+    stub(getData, "dplyr::collect", mock_df)
+
+    scoring_called <- FALSE
+    stub(getData, "MSstatsConvert::MSstatsAnomalyScores",
+         function(...) {
+           scoring_called <<- TRUE
+           mock_df
+         })
+
+    getData(input_no_runorder)
+
+    expect_false(scoring_called)
   })
 
   test_that("omits annotation + anomaly args when neither is supplied", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1577,9 +1577,101 @@ describe("getData for Big Spectronaut", {
     stub(getData, "showNotification", function(msg, ...) expect_match(msg, "Memory Error"))
     stub(getData, "shinybusy::update_modal_spinner", function(...) NULL)
     stub(getData, "shinybusy::remove_modal_spinner", function(...) NULL)
-    
+
     res <- getData(mock_input_big)
     expect_null(res)
+  })
+
+  # Capturing converter (returns its args so we can inspect what
+  # got forwarded). Same idea as mock_spectro_converter above; the
+  # big-file caller uses do.call(), but mockery intercepts the
+  # MSstatsBig::bigSpectronauttoMSstatsFormat symbol resolution
+  # rather than the call form, so this still works.
+  mock_big_spec_converter <- function(...) list(...)
+  dummy_annot_df <- data.frame(
+    Run = c("run1", "run2"),
+    BioReplicate = c(7L, 8L),
+    Condition = c("ctrl", "treat"),
+    stringsAsFactors = FALSE)
+
+  test_that("passes annotation to converter when big_spec_annotation is supplied", {
+    input_with_annot <- mock_input_big
+    input_with_annot$big_spec_annotation <- list(datapath = "annot.csv")
+
+    stub(getData, "shinyFiles::getVolumes", function() function() c(root = "/"))
+    stub(getData, "shinyFiles::parseFilePaths", function(...) data.frame(datapath = "test.csv"))
+    stub(getData, "file.exists", TRUE)
+    stub(getData, "shinybusy::update_modal_spinner", function(...) NULL)
+    stub(getData, "shinybusy::remove_modal_spinner", function(...) NULL)
+    stub(getData, "showNotification", function(...) NULL)
+    stub(getData, "data.table::fread", dummy_annot_df)
+    stub(getData, "MSstatsBig::bigSpectronauttoMSstatsFormat",
+         mock_big_spec_converter)
+    # Hijack dplyr::collect to read back what the (stubbed)
+    # converter received — getData passes its return value into
+    # collect, so the captured value IS the list of args.
+    captured_args <- NULL
+    stub(getData, "dplyr::collect", function(x) {
+      captured_args <<- x
+      mock_df
+    })
+
+    getData(input_with_annot)
+
+    expect_true(!is.null(captured_args$annotation))
+    expect_equal(captured_args$annotation, dummy_annot_df)
+  })
+
+  test_that("passes calculateAnomalyScores + anomalyModelFeatures when carry_anomaly_features = TRUE", {
+    input_with_anomaly <- mock_input_big
+    input_with_anomaly$carry_anomaly_features <- TRUE
+
+    stub(getData, "shinyFiles::getVolumes", function() function() c(root = "/"))
+    stub(getData, "shinyFiles::parseFilePaths", function(...) data.frame(datapath = "test.csv"))
+    stub(getData, "file.exists", TRUE)
+    stub(getData, "shinybusy::update_modal_spinner", function(...) NULL)
+    stub(getData, "shinybusy::remove_modal_spinner", function(...) NULL)
+    stub(getData, "showNotification", function(...) NULL)
+    stub(getData, "MSstatsBig::bigSpectronauttoMSstatsFormat",
+         mock_big_spec_converter)
+    captured_args <- NULL
+    stub(getData, "dplyr::collect", function(x) {
+      captured_args <<- x
+      mock_df
+    })
+
+    getData(input_with_anomaly)
+
+    expect_true(isTRUE(captured_args$calculateAnomalyScores))
+    expect_equal(captured_args$anomalyModelFeatures,
+                 c("FG.ShapeQualityScore (MS2)",
+                   "FG.ShapeQualityScore (MS1)",
+                   "EGDeltaRT"))
+    # No runOrder for the big-file path — the converter doesn't
+    # accept one (MSstatsBig has no MSstatsAnomalyScores call).
+    expect_null(captured_args$runOrder)
+  })
+
+  test_that("omits annotation + anomaly args when neither is supplied", {
+    stub(getData, "shinyFiles::getVolumes", function() function() c(root = "/"))
+    stub(getData, "shinyFiles::parseFilePaths", function(...) data.frame(datapath = "test.csv"))
+    stub(getData, "file.exists", TRUE)
+    stub(getData, "shinybusy::update_modal_spinner", function(...) NULL)
+    stub(getData, "shinybusy::remove_modal_spinner", function(...) NULL)
+    stub(getData, "showNotification", function(...) NULL)
+    stub(getData, "MSstatsBig::bigSpectronauttoMSstatsFormat",
+         mock_big_spec_converter)
+    captured_args <- NULL
+    stub(getData, "dplyr::collect", function(x) {
+      captured_args <<- x
+      mock_df
+    })
+
+    getData(mock_input_big)
+
+    expect_null(captured_args$annotation)
+    expect_null(captured_args$calculateAnomalyScores)
+    expect_null(captured_args$anomalyModelFeatures)
   })
 })
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1508,6 +1508,12 @@ describe("getData for Spectronaut input with anomaly scores", {
 
     stub(getData, "showNotification",
          function(msg, ...) expect_match(msg, "Run Order CSV"))
+    # getData starts with show_modal_spinner() — the validation
+    # must call remove_modal_spinner() before returning NULL so
+    # the spinner doesn't get stuck. Track that it was called.
+    spinner_removed <- FALSE
+    stub(getData, "remove_modal_spinner",
+         function(...) { spinner_removed <<- TRUE; NULL })
     # The converter should never run; if it does, fail the test.
     stub(getData, "data.table::fread",
          function(...) stop("fread reached despite missing run order"))
@@ -1516,6 +1522,7 @@ describe("getData for Spectronaut input with anomaly scores", {
 
     res <- getData(mock_input_missing_runorder)
     expect_null(res)
+    expect_true(spinner_removed)
   })
 })
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1622,10 +1622,10 @@ describe("getData for Big Spectronaut", {
     expect_equal(captured_args$annotation, dummy_annot_df)
   })
 
-  test_that("passes calculateAnomalyScores + anomalyModelFeatures to converter when carry_anomaly_features = TRUE", {
+  test_that("passes calculateAnomalyScores + anomalyModelFeatures to converter when calculate_anomaly_scores = TRUE", {
     input_with_anomaly <- mock_input_big
-    input_with_anomaly$carry_anomaly_features <- TRUE
-    input_with_anomaly$big_run_order_file <- list(datapath = "run_order.csv")
+    input_with_anomaly$calculate_anomaly_scores <- TRUE
+    input_with_anomaly$run_order_file <- list(datapath = "run_order.csv")
 
     stub(getData, "shinyFiles::getVolumes", function() function() c(root = "/"))
     stub(getData, "shinyFiles::parseFilePaths", function(...) data.frame(datapath = "test.csv"))
@@ -1662,10 +1662,10 @@ describe("getData for Big Spectronaut", {
     expect_null(captured_args$runOrder)
   })
 
-  test_that("calls MSstatsConvert::MSstatsAnomalyScores after collect when carry_anomaly_features && big_run_order_file are set", {
+  test_that("calls MSstatsConvert::MSstatsAnomalyScores after collect when calculate_anomaly_scores && run_order_file are set", {
     input_with_full_anomaly <- mock_input_big
-    input_with_full_anomaly$carry_anomaly_features <- TRUE
-    input_with_full_anomaly$big_run_order_file <- list(datapath = "run_order.csv")
+    input_with_full_anomaly$calculate_anomaly_scores <- TRUE
+    input_with_full_anomaly$run_order_file <- list(datapath = "run_order.csv")
 
     stub(getData, "shinyFiles::getVolumes", function() function() c(root = "/"))
     stub(getData, "shinyFiles::parseFilePaths", function(...) data.frame(datapath = "test.csv"))
@@ -1710,10 +1710,10 @@ describe("getData for Big Spectronaut", {
     expect_equal(captured_scoring_args$cores, 1)
   })
 
-  test_that("does NOT call MSstatsAnomalyScores when carry_anomaly_features is TRUE but big_run_order_file is missing", {
+  test_that("does NOT call MSstatsAnomalyScores when calculate_anomaly_scores is TRUE but run_order_file is missing", {
     input_no_runorder <- mock_input_big
-    input_no_runorder$carry_anomaly_features <- TRUE
-    input_no_runorder$big_run_order_file <- NULL
+    input_no_runorder$calculate_anomaly_scores <- TRUE
+    input_no_runorder$run_order_file <- NULL
 
     stub(getData, "shinyFiles::getVolumes", function() function() c(root = "/"))
     stub(getData, "shinyFiles::parseFilePaths", function(...) data.frame(datapath = "test.csv"))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

This PR extends MSstatsShiny's Spectronaut large-file processing capabilities to support annotation file uploads and anomaly score calculation on converted datasets. The changes address user workflows that require:
- Dynamic intensity column selection based on configured templates (protein turnover vs. standard quantitation)
- Metadata override via optional CSV annotation uploads for BigSpectronaut files
- Post-conversion anomaly score detection using run-order information

The implementation refactors the data loading pipeline to integrate these new Spectronaut-specific options while maintaining backward compatibility with existing processing workflows.

## Detailed Changes

### R/module-loadpage-server.R
- Replaced hardcoded `spec_intensity_col` text input with dynamic `spectronaut_intensity_ui` reactive output rendered conditionally for Spectronaut files (`filetype == 'spec'` and `BIO != 'PTM'`)
- Dynamic intensity column defaults: `FG.MS1Quantity` for protein turnover templates, otherwise `F.NormalizedPeakArea`
- Added descriptive tooltip/help text to the intensity column control
- Extended Spectronaut large-file options path to:
  - Capture `calculate_anomaly_scores` checkbox input
  - Conditionally render `create_spectronaut_large_annotation_ui()` within the large-file UI options

### R/module-loadpage-ui.R
- Added `uiOutput("spectronaut_intensity_ui")` placeholder for dynamic intensity control rendering
- Created new UI factory function `create_spectronaut_large_annotation_ui(ns, calculate_anomaly_def = FALSE)` providing:
  - Optional CSV annotation file uploader (`big_spec_annotation`) for metadata overrides
  - Checkbox input (`calculate_anomaly_scores`) to toggle anomaly scoring
  - Conditional run-order CSV file input (`run_order_file`) displayed only when anomaly scoring is enabled

### R/utils.R
- Refactored BigSpectronaut data conversion to build a reusable argument list (`big_spec_args`) and invoke `MSstatsBig::bigSpectronauttoMSstatsFormat` via `do.call`
- Added conditional parameter injection for:
  - User-selected intensity column value
  - Annotation file path override
  - Anomaly scoring flags and model features
- Implemented post-conversion anomaly scoring:
  - Conditionally invokes `MSstatsConvert::MSstatsAnomalyScores` after `dplyr::collect` when both `calculate_anomaly_scores=TRUE` and `run_order_file` are provided
  - Forwards quality metrics, temporal direction, run order, and tree/NN hyperparameters to anomaly scorer
  - Prevents `runOrder` from being passed to the converter itself (consumed only by post-collection anomaly scorer)
- Updated `getDataCode()` generation for Spectronaut paths:
  - Large-file branch: Generates code for `bigSpectronauttoMSstatsFormat` followed by optional `MSstatsAnomalyScores` step
  - Non-large-file branch: Precomputes optional `intensity` parameter snippet for reuse in `SpectronauttoMSstatsFormat` call

## Unit Tests

### tests/testthat/test-utils.R
Extended BigSpectronaut test coverage with 201 added/modified lines:
- **Annotation file forwarding**: Verifies `big_spec_annotation` datapath is correctly passed to `MSstatsBig::bigSpectronauttoMSstatsFormat`
- **Anomaly scoring parameters**: Confirms `calculateAnomalyScores=TRUE` and `anomalyModelFeatures` are forwarded to converter; validates that `runOrder` is *not* passed to the converter (used only post-collection)
- **Post-collection anomaly application**: Tests that `MSstatsConvert::MSstatsAnomalyScores` is invoked after `dplyr::collect` when both `calculate_anomaly_scores=TRUE` and `run_order_file` are present, with correct argument forwarding (quality metrics, temporal direction, run order, tree/NN hyperparameters)
- **Conditional anomaly scoring**: Verifies `MSstatsAnomalyScores` is not called when `calculate_anomaly_scores=TRUE` but `run_order_file` is missing
- **Intensity column mapping**: Confirms `spec_intensity_col` is correctly forwarded as `intensity` parameter to converter
- **Null handling**: Tests that converter receives `NULL` for both `annotation` and anomaly-related arguments when neither option is supplied
- **Converter mocking strategy**: Uses direct function stubbing of `MSstatsBig::bigSpectronauttoMSstatsFormat` to intercept arguments, accounting for the `do.call` invocation pattern

## Coding Guidelines

No coding guideline violations identified. The implementation follows established project patterns:
- UI factory functions adhere to naming convention (`create_*_ui`)
- Reactive output rendering with conditional logic aligns with Shiny module architecture
- Use of `do.call` for flexible optional parameter forwarding follows standard R practices
- Test structure with function stubs via mockery package is consistent with existing test suite
- Separation of annotation and anomaly scoring concerns maintains code clarity and maintainability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Vitek-Lab/MSstatsShiny/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->