### PR TITLE
fix(fragpipe): Fix PTM tooltip w.r.t. column name

### DIFF
--- a/R/module-loadpage-ui.R
+++ b/R/module-loadpage-ui.R
@@ -536,7 +536,7 @@ create_ptm_fragpipe_uploads <- function(ns) {
     textInput(ns("mod_id_col"), 
               h5("Please enter the name of the modification id column", class = "icon-wrapper", 
                  icon("question-circle", lib = "font-awesome"),
-                 div("Only part of the string is required. For example if your mod id column is named 'STY:1221.12' you only need to enter 'STY' here.", class = "icon-tooltip")),
+                 div("Only part of the string is required. For example if your mod id column is named 'STY.1221.12' you only need to enter 'STY' here.", class = "icon-tooltip")),
               value = "STY"),
     
     textInput(ns("localization_cutoff"), 


### PR DESCRIPTION
The column name in fragpipe for a PTM is in the format `aminoAcid.mass`, not `aminoAcid:mass`

Context: https://groups.google.com/g/msstats/c/xiI51iq0neM