### PR TITLE
Add metabolomics template and MZmine converter (loadpage)

### DIFF
--- a/R/constants.R
+++ b/R/constants.R
@@ -113,7 +113,8 @@ NAMESPACE_LOADPAGE = list(
   summary_nonptm_panel = "summary_nonptm_panel",
   summary_ptm_panel = "summary_ptm_panel",
   tmt_options_ui = "tmt_options_ui",
-  mzmine_upload_panel = "mzmine_upload_panel"
+  mzmine_upload_panel = "mzmine_upload_panel",
+  main_selection_divider = "main_selection_divider"
 )
 
 # File-type choices for the loadpage converter radio.

--- a/R/constants.R
+++ b/R/constants.R
@@ -1,14 +1,16 @@
 TEMPLATES = list(
   default = "default",
   chemoproteomics = "chemoproteomics",
-  protein_turnover = "protein_turnover"
+  protein_turnover = "protein_turnover",
+  metabolomics = "metabolomics"
   
 )
 
 TEMPLATE_LABELS = list(
   default = "Protein Differential Abundance Analysis",
   chemoproteomics = "Chemoproteomics",
-  protein_turnover = "Protein Turnover"
+  protein_turnover = "Protein Turnover",
+  metabolomics = "Metabolite Differential Abundance Analysis"
   
 )
 
@@ -110,8 +112,19 @@ NAMESPACE_LOADPAGE = list(
   openswath_mscore_cutoff_panel = "openswath_mscore_cutoff_panel",
   summary_nonptm_panel = "summary_nonptm_panel",
   summary_ptm_panel = "summary_ptm_panel",
-  tmt_options_ui = "tmt_options_ui"
+  tmt_options_ui = "tmt_options_ui",
+  mzmine_upload_panel = "mzmine_upload_panel"
 )
+
+# File-type choices for the loadpage converter radio.
+LOADPAGE_FILETYPE_CHOICES = c("Example dataset" = "sample",
+                              "MSstats Format" = "msstats",
+                              "Skyline" = "sky", "MaxQuant" = "maxq",
+                              "Progenesis" = "prog", "Proteome Discoverer" = "PD",
+                              "OpenMS" = "openms", "Spectronaut" = "spec",
+                              "OpenSWATH" = "open", "DIA-Umpire" = "ump",
+                              "SpectroMine" = "spmin", "FragPipe" = "phil", "DIANN"="diann",
+                              "Metamorpheus" = "meta")
 
 NAMESPACE_QC = list(
   # Sidebar processing-option input ids

--- a/R/constants.R
+++ b/R/constants.R
@@ -127,6 +127,12 @@ LOADPAGE_FILETYPE_CHOICES = c("Example dataset" = "sample",
                               "SpectroMine" = "spmin", "FragPipe" = "phil", "DIANN"="diann",
                               "Metamorpheus" = "meta")
 
+# File-type choices under the metabolomics template: the MZmine converter or a
+# pre-formatted MSstats table. Kept as a constant so the restrict observer and
+# its test share one source of truth.
+LOADPAGE_METABOLOMICS_FILETYPE_CHOICES = c("MZmine" = "mzmine",
+                                           "MSstats Format" = "msstats")
+
 NAMESPACE_QC = list(
   # Sidebar processing-option input ids
   global_norm = "global_norm",

--- a/R/loadpage-server-converter-options-panel.R
+++ b/R/loadpage-server-converter-options-panel.R
@@ -185,15 +185,18 @@ loadpage_show_mzmine_upload <- function(filetype) {
   isTRUE(filetype == "mzmine")
 }
 
-#' Label-free options block (`unique_peptides`, `remove`). Suppressed for
-#' the sample-data and big-file workflows.
+#' Label-free options block (`unique_peptides`, `remove`). Suppressed for the
+#' sample-data and big-file workflows, and for the metabolomics template
+#' (pre-processing options do not apply to metabolites).
 #' @noRd
-loadpage_show_label_free_options <- function(filetype, dda_dia, big_file_spec, big_file_diann) {
+loadpage_show_label_free_options <- function(filetype, dda_dia, big_file_spec,
+                                             big_file_diann, app_template = NULL) {
   if (is.null(filetype) || !nzchar(filetype)) return(FALSE)
   isTRUE(dda_dia == "LType") &&
     !isTRUE(filetype == "sample") &&
     !(isTRUE(filetype == "spec")  && isTRUE(big_file_spec))  &&
-    !(isTRUE(filetype == "diann") && isTRUE(big_file_diann))
+    !(isTRUE(filetype == "diann") && isTRUE(big_file_diann)) &&
+    !isTRUE(app_template == TEMPLATES$metabolomics)
 }
 
 #' OpenSWATH M-score filter section (parent of `mscore_cutoff`).
@@ -304,19 +307,6 @@ loadpage_show_ptm_summary <- function(bio) {
 }
 
 
-#' Build the "Type of File" header. Numbered "3. " except under the metabolomics
-#' template (where the hidden "1."/"2." sections would leave a lone number).
-#' Pure, so the number/tooltip behavior is unit-testable directly.
-#' @noRd
-loadpage_filetype_header <- function(template) {
-  prefix = if (isTRUE(template == TEMPLATES$metabolomics)) "" else "3. "
-  h4(paste0(prefix, "Type of File"), class = "icon-wrapper",
-     icon("question-circle", lib = "font-awesome"),
-     div("Choose the spectral processing tool used to process your data",
-         class = "icon-tooltip"))
-}
-
-
 # ----------------------------------------------------------------------------
 # Unified registration helper.
 # ----------------------------------------------------------------------------
@@ -357,13 +347,6 @@ register_loadpage_visibility_observers <- function(input, output, session, app_t
     }
   })
 
-  # The "Type of File" header drops its "3." under the metabolomics template,
-  # where the hidden "1."/"2." sections would otherwise leave it a lone number;
-  # every other template keeps the original numbered "3. Type of File" header.
-  output$filetype_header = renderUI({
-    loadpage_filetype_header(if (!is.null(app_template)) app_template() else NULL)
-  })
-
   # Upload-area description: metabolomics-specific guidance under that template,
   # the default proteomics guidance (create_header_content) otherwise.
   output$upload_description = renderUI({
@@ -373,6 +356,7 @@ register_loadpage_visibility_observers <- function(input, output, session, app_t
       create_header_content()
     }
   })
+
   if (!is.null(app_template)) {
     observeEvent(app_template(), {
       if (app_template() == TEMPLATES$metabolomics) {
@@ -638,11 +622,9 @@ register_loadpage_visibility_observers <- function(input, output, session, app_t
         input[[NAMESPACE_LOADPAGE$filetype]],
         input[[NAMESPACE_LOADPAGE$dda_dia]],
         input[[NAMESPACE_LOADPAGE$big_file_spec]],
-        input[[NAMESPACE_LOADPAGE$big_file_diann]]
-      ) &&
-        # Pre-processing options (unique peptides / remove 1-feature proteins)
-        # do not apply to metabolites; hide the whole block under metabolomics.
-        !(!is.null(app_template) && app_template() == TEMPLATES$metabolomics)
+        input[[NAMESPACE_LOADPAGE$big_file_diann]],
+        if (!is.null(app_template)) app_template() else NULL
+      )
     )
   })
   observe({
@@ -662,13 +644,6 @@ register_loadpage_visibility_observers <- function(input, output, session, app_t
       )
     )
   })
-
-  # The post-proceed1 "Top 6 rows" preview panels (non-PTM vs PTM) are
-  # display-only tables. Their visibility is decided at render time inside the
-  # `summary_tables` renderUI in `register_loadpage_summary`, via
-  # loadpage_show_nonptm_summary / loadpage_show_ptm_summary (below), NOT by a
-  # shinyjs::toggle observer here: those divs are (re)built by that renderUI on
-  # each `proceed1`, and a toggle raced the re-insertion and left them hidden.
 
   # --- TMT which.proteinid renderUI (the duplicate-ns()-id case) -------------
   #

--- a/R/loadpage-server-converter-options-panel.R
+++ b/R/loadpage-server-converter-options-panel.R
@@ -345,15 +345,15 @@ register_loadpage_visibility_observers <- function(input, output, session, app_t
   # value carried over from a prior template.
   observe({
     metab = !is.null(app_template) && app_template() == TEMPLATES$metabolomics
-    shinyjs::toggle("BIO",     condition = !metab)
-    shinyjs::toggle("DDA_DIA", condition = !metab)
+    shinyjs::toggle(NAMESPACE_LOADPAGE$bio,     condition = !metab)
+    shinyjs::toggle(NAMESPACE_LOADPAGE$dda_dia, condition = !metab)
     # Also hide the divider that follows the selection block, so under
     # metabolomics a single divider (the one after the hidden label-free panel)
     # remains above the upload sections instead of two adjacent hr lines.
-    shinyjs::toggle("main_selection_divider", condition = !metab)
+    shinyjs::toggle(NAMESPACE_LOADPAGE$main_selection_divider, condition = !metab)
     if (metab) {
-      updateRadioButtons(session, "BIO",     selected = "Protein")
-      updateRadioButtons(session, "DDA_DIA", selected = "LType")
+      updateRadioButtons(session, NAMESPACE_LOADPAGE$bio,     selected = "Protein")
+      updateRadioButtons(session, NAMESPACE_LOADPAGE$dda_dia, selected = "LType")
     }
   })
 
@@ -366,10 +366,10 @@ register_loadpage_visibility_observers <- function(input, output, session, app_t
   if (!is.null(app_template)) {
     observeEvent(app_template(), {
       if (app_template() == TEMPLATES$metabolomics) {
-        updateRadioButtons(session, "filetype",
+        updateRadioButtons(session, NAMESPACE_LOADPAGE$filetype,
                            choices = c("MZmine" = "mzmine"), selected = "mzmine")
       } else {
-        updateRadioButtons(session, "filetype",
+        updateRadioButtons(session, NAMESPACE_LOADPAGE$filetype,
                            choices = LOADPAGE_FILETYPE_CHOICES, selected = character(0))
       }
     })

--- a/R/loadpage-server-converter-options-panel.R
+++ b/R/loadpage-server-converter-options-panel.R
@@ -177,6 +177,14 @@ loadpage_show_dia_umpire_upload <- function(filetype) {
   isTRUE(filetype == "ump")
 }
 
+#' Show the MZmine upload panel (metabolomics converter). Gated on the converter
+#' (filetype == "mzmine"), matching the other converter-upload panels, not on
+#' the template.
+#' @noRd
+loadpage_show_mzmine_upload <- function(filetype) {
+  isTRUE(filetype == "mzmine")
+}
+
 #' Label-free options block (`unique_peptides`, `remove`). Suppressed for
 #' the sample-data and big-file workflows.
 #' @noRd
@@ -296,6 +304,19 @@ loadpage_show_ptm_summary <- function(bio) {
 }
 
 
+#' Build the "Type of File" header. Numbered "3. " except under the metabolomics
+#' template (where the hidden "1."/"2." sections would leave a lone number).
+#' Pure, so the number/tooltip behavior is unit-testable directly.
+#' @noRd
+loadpage_filetype_header <- function(template) {
+  prefix = if (isTRUE(template == TEMPLATES$metabolomics)) "" else "3. "
+  h4(paste0(prefix, "Type of File"), class = "icon-wrapper",
+     icon("question-circle", lib = "font-awesome"),
+     div("Choose the spectral processing tool used to process your data",
+         class = "icon-tooltip"))
+}
+
+
 # ----------------------------------------------------------------------------
 # Unified registration helper.
 # ----------------------------------------------------------------------------
@@ -314,7 +335,54 @@ loadpage_show_ptm_summary <- function(bio) {
 #' @param output  the Shiny module's `output` object (for the TMT renderUI)
 #' @param session the Shiny module's `session` (for `session$ns`)
 #' @noRd
-register_loadpage_visibility_observers <- function(input, output, session) {
+register_loadpage_visibility_observers <- function(input, output, session, app_template = NULL) {
+  # --- Metabolomics template -------------------------------------------------
+  # Hide the biological-question and label-type radios under the metabolomics
+  # template, restrict the file-type radio to MZmine, and reset BIO/DDA_DIA to
+  # Protein/LType. Metabolomics data IS label-free non-PTM, so resetting at
+  # template selection makes every downstream consumer (getData, the summary
+  # tables, tab visibility) see the correct state instead of a stale BIO/DDA_DIA
+  # value carried over from a prior template.
+  observe({
+    metab = !is.null(app_template) && app_template() == TEMPLATES$metabolomics
+    shinyjs::toggle("BIO",     condition = !metab)
+    shinyjs::toggle("DDA_DIA", condition = !metab)
+    # Also hide the divider that follows the selection block, so under
+    # metabolomics a single divider (the one after the hidden label-free panel)
+    # remains above the upload sections instead of two adjacent hr lines.
+    shinyjs::toggle("main_selection_divider", condition = !metab)
+    if (metab) {
+      updateRadioButtons(session, "BIO",     selected = "Protein")
+      updateRadioButtons(session, "DDA_DIA", selected = "LType")
+    }
+  })
+
+  # The "Type of File" header drops its "3." under the metabolomics template,
+  # where the hidden "1."/"2." sections would otherwise leave it a lone number;
+  # every other template keeps the original numbered "3. Type of File" header.
+  output$filetype_header = renderUI({
+    loadpage_filetype_header(if (!is.null(app_template)) app_template() else NULL)
+  })
+  if (!is.null(app_template)) {
+    observeEvent(app_template(), {
+      if (app_template() == TEMPLATES$metabolomics) {
+        updateRadioButtons(session, "filetype",
+                           choices = c("MZmine" = "mzmine"), selected = "mzmine")
+      } else {
+        updateRadioButtons(session, "filetype",
+                           choices = LOADPAGE_FILETYPE_CHOICES, selected = character(0))
+      }
+    })
+  }
+  # MZmine upload panel: gated on the converter (filetype == "mzmine"), matching
+  # the other converter-upload panels, not on the template.
+  observe({
+    shinyjs::toggle(
+      NAMESPACE_LOADPAGE$mzmine_upload_panel,
+      condition = loadpage_show_mzmine_upload(input[[NAMESPACE_LOADPAGE$filetype]])
+    )
+  })
+
   # --- DIANN cluster ---------------------------------------------------------
   observe({
     shinyjs::toggle(

--- a/R/loadpage-server-converter-options-panel.R
+++ b/R/loadpage-server-converter-options-panel.R
@@ -363,11 +363,22 @@ register_loadpage_visibility_observers <- function(input, output, session, app_t
   output$filetype_header = renderUI({
     loadpage_filetype_header(if (!is.null(app_template)) app_template() else NULL)
   })
+
+  # Upload-area description: metabolomics-specific guidance under that template,
+  # the default proteomics guidance (create_header_content) otherwise.
+  output$upload_description = renderUI({
+    if (!is.null(app_template) && app_template() == TEMPLATES$metabolomics) {
+      create_metabolomics_header_content()
+    } else {
+      create_header_content()
+    }
+  })
   if (!is.null(app_template)) {
     observeEvent(app_template(), {
       if (app_template() == TEMPLATES$metabolomics) {
         updateRadioButtons(session, NAMESPACE_LOADPAGE$filetype,
-                           choices = c("MZmine" = "mzmine"), selected = "mzmine")
+                           choices = LOADPAGE_METABOLOMICS_FILETYPE_CHOICES,
+                           selected = "mzmine")
       } else {
         updateRadioButtons(session, NAMESPACE_LOADPAGE$filetype,
                            choices = LOADPAGE_FILETYPE_CHOICES, selected = character(0))
@@ -628,7 +639,10 @@ register_loadpage_visibility_observers <- function(input, output, session, app_t
         input[[NAMESPACE_LOADPAGE$dda_dia]],
         input[[NAMESPACE_LOADPAGE$big_file_spec]],
         input[[NAMESPACE_LOADPAGE$big_file_diann]]
-      )
+      ) &&
+        # Pre-processing options (unique peptides / remove 1-feature proteins)
+        # do not apply to metabolites; hide the whole block under metabolomics.
+        !(!is.null(app_template) && app_template() == TEMPLATES$metabolomics)
     )
   })
   observe({
@@ -649,33 +663,12 @@ register_loadpage_visibility_observers <- function(input, output, session, app_t
     )
   })
 
-  # --- Post-proceed1 summary tables (BIO-driven) -----------------------------
-  # Unlike the static converter panels above, these two divs are emitted by the
-  # `summary_tables` renderUI in `register_loadpage_summary`, which (re)builds
-  # only when `proceed1` fires — so they do not exist at the app's first flush.
-  # Each observer therefore also takes a dependency on `proceed1`, so it
-  # re-fires once the renderUI has (re)mounted the divs and applies the correct
-  # initial visibility. (Shiny applies output values before custom messages
-  # within a response, so the toggle lands after the divs are inserted.) BIO is
-  # read the same way as the other BIO-driven predicates.
-  observe({
-    input[[NAMESPACE_LOADPAGE$proceed1]]
-    shinyjs::toggle(
-      NAMESPACE_LOADPAGE$summary_nonptm_panel,
-      condition = loadpage_show_nonptm_summary(
-        input[[NAMESPACE_LOADPAGE$bio]]
-      )
-    )
-  })
-  observe({
-    input[[NAMESPACE_LOADPAGE$proceed1]]
-    shinyjs::toggle(
-      NAMESPACE_LOADPAGE$summary_ptm_panel,
-      condition = loadpage_show_ptm_summary(
-        input[[NAMESPACE_LOADPAGE$bio]]
-      )
-    )
-  })
+  # The post-proceed1 "Top 6 rows" preview panels (non-PTM vs PTM) are
+  # display-only tables. Their visibility is decided at render time inside the
+  # `summary_tables` renderUI in `register_loadpage_summary`, via
+  # loadpage_show_nonptm_summary / loadpage_show_ptm_summary (below), NOT by a
+  # shinyjs::toggle observer here: those divs are (re)built by that renderUI on
+  # each `proceed1`, and a toggle raced the re-insertion and left them hidden.
 
   # --- TMT which.proteinid renderUI (the duplicate-ns()-id case) -------------
   #

--- a/R/loadpage-server-proceed-validation.R
+++ b/R/loadpage-server-proceed-validation.R
@@ -18,7 +18,16 @@ register_loadpage_proceed_validation <- function(input, session,
                                                   local_big_diann_path) {
   observe({
     disable("proceed1")
-    if (((input$BIO == "Protein") || (input$BIO == "Peptide"))) {
+    if (isTRUE(input$filetype == "mzmine")) {
+      # Converter-gated (not template-gated), like the rest of the MZmine wiring,
+      # so it enables regardless of any stale BIO/DDA_DIA values carried over
+      # from a prior template. SIRIUS annotations stay ungated (optional).
+      if (!is.null(input$mzmine_input) &&
+          !is.null(input$mzmine_annotation) &&
+          !is.null(input$mzmine_annotations)) {
+        enable("proceed1")
+      }
+    } else if (((input$BIO == "Protein") || (input$BIO == "Peptide"))) {
       if (input$DDA_DIA == "LType") {
         if ((!is.null(input$filetype) && length(input$filetype) > 0)) {
           if (input$filetype == "sample") {

--- a/R/loadpage-server-summary.R
+++ b/R/loadpage-server-summary.R
@@ -118,9 +118,11 @@ register_loadpage_summary <- function(input, output, session, parent_session,
       data_summary <- describe(data1)
     })
 
-    output$summary <- renderTable(
+    output$summary = renderTable(
       {
-        head(get_data())
+        d = get_data()
+        if (!is.null(app_template) && app_template() == TEMPLATES$metabolomics)
+          head(metabolomics_preview_view(d)) else head(d)
       }, bordered = TRUE
     )
     output$summary_ptm <- renderTable(

--- a/R/loadpage-server-summary.R
+++ b/R/loadpage-server-summary.R
@@ -203,13 +203,6 @@ register_loadpage_summary <- function(input, output, session, parent_session,
         h4("Summary of dataset"),
         tableOutput(ns("summary2")),
         tags$br(),
-        # Data preview (display-only, no inputs): render the correct table(s)
-        # here, visibly, chosen by BIO. Built in the renderUI rather than mounted
-        # hidden and revealed by a shinyjs::toggle observer: that observer raced
-        # the renderUI re-inserting the hidden div and left the panel hidden,
-        # dropping the preview (regression vs the pre-refactor conditionalPanel).
-        # Metabolomics resets BIO to a non-PTM value, so it takes the non-PTM
-        # branch, where output$summary already swaps in metabolomics_preview_view.
         if (loadpage_show_nonptm_summary(input[[NAMESPACE_LOADPAGE$bio]]))
           div(id = ns(NAMESPACE_LOADPAGE$summary_nonptm_panel),
               h4("Top 6 rows of the dataset"),

--- a/R/loadpage-server-summary.R
+++ b/R/loadpage-server-summary.R
@@ -1,6 +1,31 @@
 # Loadpage condition-metadata DT editor + the post-`proceed1` summary outputs and experimental-design summary statistics (number of conditions, number of replicates, etc.).
 
 
+#' Relabel the dataset-summary rows for the metabolomics template.
+#'
+#' `getSummary2()` returns a 2-column (label, value) frame with proteomics
+#' wording. For metabolomics data (`ProteinName` = metabolite, `PeptideSequence`
+#' = feature, charge columns NA) two rows are redundant: the distinct-`FEATURES`
+#' count equals the distinct-feature count, and features-per-peptide is always
+#' `1 - 1`. Drop those two, then rename the survivors. Drop must precede the
+#' rename: renaming "Number of Peptides" to "Number of Features" first would
+#' collide with the "Number of Features" row that needs to be dropped.
+#' @noRd
+metabolomics_summary2_view <- function(summary2) {
+  labels = as.character(summary2[[1]])
+  keep = !(labels %in% c("Number of Features", "Number of Features/Peptide"))
+  summary2 = summary2[keep, , drop = FALSE]
+  relabel = c("Number of Proteins"         = "Number of Metabolites",
+              "Number of Peptides"         = "Number of Features",
+              "Number of Peptides/Protein" = "Number of Features/Metabolite")
+  labels = as.character(summary2[[1]])
+  hit = labels %in% names(relabel)
+  labels[hit] = relabel[labels[hit]]
+  summary2[[1]] = labels
+  summary2
+}
+
+
 #' Register the loadpage post-`proceed1` summary cluster.
 #'
 #' @param input              the Shiny module's `input` object
@@ -110,14 +135,6 @@ register_loadpage_summary <- function(input, output, session, parent_session,
     }
 
     ### outputs ###
-    get_summary <- reactive({
-      if (is.null(get_data())) {
-        return(NULL)
-      }
-      data1 <- get_data()
-      data_summary <- describe(data1)
-    })
-
     output$summary = renderTable(
       {
         d = get_data()
@@ -148,8 +165,9 @@ register_loadpage_summary <- function(input, output, session, parent_session,
     output$summary2 <- renderTable(
       {
         req(get_data())
-        get_summary2()
-
+        s = get_summary2()
+        if (!is.null(app_template) && app_template() == TEMPLATES$metabolomics)
+          metabolomics_summary2_view(s) else s
       }, colnames = FALSE, bordered = TRUE, align = 'lr'
     )
 
@@ -185,17 +203,26 @@ register_loadpage_summary <- function(input, output, session, parent_session,
         h4("Summary of dataset"),
         tableOutput(ns("summary2")),
         tags$br(),
-        shinyjs::hidden(div(id = ns(NAMESPACE_LOADPAGE$summary_nonptm_panel),
-                         h4("Top 6 rows of the dataset"),
-                         div(style = "overflow-x: auto;", tableOutput(ns("summary")))
-        )),
-        shinyjs::hidden(div(id = ns(NAMESPACE_LOADPAGE$summary_ptm_panel),
-                         h4("Top 6 rows of the PTM dataset"),
-                         div(style = "overflow-x: auto;", tableOutput(ns("summary_ptm"))),
-                         tags$br(),
-                         h4("Top 6 rows of the unmodified protein dataset"),
-                         div(style = "overflow-x: auto;", tableOutput(ns("summary_prot")))
-        ))
+        # Data preview (display-only, no inputs): render the correct table(s)
+        # here, visibly, chosen by BIO. Built in the renderUI rather than mounted
+        # hidden and revealed by a shinyjs::toggle observer: that observer raced
+        # the renderUI re-inserting the hidden div and left the panel hidden,
+        # dropping the preview (regression vs the pre-refactor conditionalPanel).
+        # Metabolomics resets BIO to a non-PTM value, so it takes the non-PTM
+        # branch, where output$summary already swaps in metabolomics_preview_view.
+        if (loadpage_show_nonptm_summary(input[[NAMESPACE_LOADPAGE$bio]]))
+          div(id = ns(NAMESPACE_LOADPAGE$summary_nonptm_panel),
+              h4("Top 6 rows of the dataset"),
+              div(style = "overflow-x: auto;", tableOutput(ns("summary")))
+          ),
+        if (loadpage_show_ptm_summary(input[[NAMESPACE_LOADPAGE$bio]]))
+          div(id = ns(NAMESPACE_LOADPAGE$summary_ptm_panel),
+              h4("Top 6 rows of the PTM dataset"),
+              div(style = "overflow-x: auto;", tableOutput(ns("summary_ptm"))),
+              tags$br(),
+              h4("Top 6 rows of the unmodified protein dataset"),
+              div(style = "overflow-x: auto;", tableOutput(ns("summary_prot")))
+          )
       )
     })
 

--- a/R/module-loadpage-server.R
+++ b/R/module-loadpage-server.R
@@ -94,7 +94,7 @@ loadpageServer <- function(id, parent_session, is_web_server = FALSE, app_templa
 
     register_loadpage_preview(input, output, session)
 
-    register_loadpage_visibility_observers(input, output, session)
+    register_loadpage_visibility_observers(input, output, session, app_template = app_template)
 
     register_loadpage_converter_ui(
       input, output, session,

--- a/R/module-loadpage-ui.R
+++ b/R/module-loadpage-ui.R
@@ -19,8 +19,8 @@ loadpageUI <- function(id) {
       useShinyjs(),
       headerPanel(list("Upload data")),
       
-      # Header content
-      create_header_content(),
+      # Header content (template-aware: proteomics default vs metabolomics text)
+      uiOutput(ns("upload_description")),
       
       tags$br(),
       
@@ -85,6 +85,22 @@ create_header_content <- function() {
         target="_blank")),
     p("Note: files must be in CSV/TSV format, or Parquet (.parquet/.pq) for DIANN 2.0+ inputs, and under 250 MB when using msstatsshiny.com. When running the app locally, Spectronaut and DIANN reports above this limit can be processed via 'Large file mode' (out-of-memory streaming through MSstatsBig)."),
     p("Some users may have trouble uploading files while using the application via Google Chrome. If the 'Browse...' button does not work please try a different web browser.")
+  )
+}
+
+#' Create the metabolomics upload description (MZmine / MSstats-format inputs).
+#'
+#' The metabolomics branch of `output$upload_description`; factored out as a
+#' pure builder (mirroring `create_header_content`) so its text is unit-testable.
+#' @noRd
+create_metabolomics_header_content <- function() {
+  tagList(
+    p("To run the metabolomics pipeline, upload your MZmine feature quant",
+      "table and an annotation file, plus MZmine compound annotations and",
+      "(recommended) SIRIUS structure annotations. The output of this step",
+      "is your data in MSstats format."),
+    p("Note: files must be in CSV/TSV format and under 250 MB when using",
+      "msstatsshiny.com.")
   )
 }
 
@@ -274,10 +290,26 @@ create_skyline_uploads <- function(ns) {
 create_mzmine_uploads <- function(ns) {
   shinyjs::hidden(div(
     id = ns(NAMESPACE_LOADPAGE$mzmine_upload_panel),
-    fileInput(ns("mzmine_input"),       "MZmine feature quant table"),
-    fileInput(ns("mzmine_annotation"),  "Annotation file"),
-    fileInput(ns("mzmine_annotations"), "MZmine compound annotations"),
-    fileInput(ns("sirius_annotations"), "SIRIUS annotations (optional, recommended)")
+    fileInput(ns("mzmine_input"),
+              h5("MZmine feature quant table", class = "icon-wrapper",
+                 icon("question-circle", lib = "font-awesome"),
+                 div("The feature intensity table exported from MZmine (features x samples).",
+                     class = "icon-tooltip"))),
+    fileInput(ns("mzmine_annotation"),
+              h5("Annotation file", class = "icon-wrapper",
+                 icon("question-circle", lib = "font-awesome"),
+                 div("Maps each run/sample to its condition and bioreplicate.",
+                     class = "icon-tooltip"))),
+    fileInput(ns("mzmine_annotations"),
+              h5("MZmine compound annotations", class = "icon-wrapper",
+                 icon("question-circle", lib = "font-awesome"),
+                 div("MZmine's feature-to-compound identifications.",
+                     class = "icon-tooltip"))),
+    fileInput(ns("sirius_annotations"),
+              h5("SIRIUS annotations (optional, recommended)", class = "icon-wrapper",
+                 icon("question-circle", lib = "font-awesome"),
+                 div("Optional SIRIUS structure identifications; recommended to improve compound naming.",
+                     class = "icon-tooltip")))
   ))
 }
 

--- a/R/module-loadpage-ui.R
+++ b/R/module-loadpage-ui.R
@@ -152,7 +152,7 @@ create_main_selection_controls <- function(ns) {
   tagList(
     # Biological Question
     radioButtons(ns("BIO"),
-                 label = h4("1. Biological Question", class = "icon-wrapper",
+                 label = h4("Biological Question", class = "icon-wrapper",
                              icon("question-circle", lib = "font-awesome"),
                              div("Select the biological question of interest.", class = "icon-tooltip")),
                  c("Protein"="Protein", "Peptide"="Peptide","PTM"="PTM")
@@ -160,7 +160,7 @@ create_main_selection_controls <- function(ns) {
     
     # Label Type
     radioButtons(ns("DDA_DIA"),
-                 label = h4("2. Label Type", class = "icon-wrapper",
+                 label = h4("Label Type", class = "icon-wrapper",
                              icon("question-circle", lib = "font-awesome"),
                              div("Label-free will process all label-free acquisitions including DDA/DIA/SRM/PRM.", class = "icon-tooltip")),
                  c("Label-Free"="LType", "TMT"="TMT")
@@ -168,7 +168,9 @@ create_main_selection_controls <- function(ns) {
     
     # File Type
     radioButtons(ns("filetype"),
-                 label = uiOutput(ns("filetype_header")),
+                 label = h4("Type of File", class = "icon-wrapper",
+                             icon("question-circle", lib = "font-awesome"),
+                             div("Choose the spectral processing tool used to process your data", class = "icon-tooltip")),
                  choices = LOADPAGE_FILETYPE_CHOICES,
                  selected = character(0)
     )
@@ -181,7 +183,7 @@ create_label_free_type_selection <- function(ns) {
   shinyjs::hidden(div(
     id = ns(NAMESPACE_LOADPAGE$label_free_type_selection_panel),
     radioButtons(ns(NAMESPACE_LOADPAGE$label_free_type),
-                 label = h4("4. Type of Label-Free type", class = "icon-wrapper",
+                 label = h4("Type of Label-Free type", class = "icon-wrapper",
                              icon("question-circle", lib = "font-awesome"),
                              div("Choose the spectral processing tool used to process your data", class = "icon-tooltip")),
                  choices = c("DDA" = "DDA", "DIA" ="DIA", "SRM/PRM" ="SRM_PRM"),
@@ -234,7 +236,7 @@ create_file_upload_sections <- function(ns) {
 create_standard_uploads <- function(ns) {
   shinyjs::hidden(div(
     id = ns(NAMESPACE_LOADPAGE$standard_quant_upload_panel),
-    h4("4. Upload quantification dataset"),
+    h4("Upload quantification dataset"),
     fileInput(ns('data'), "", multiple = FALSE, accept = NULL)
   ))
 }
@@ -244,7 +246,7 @@ create_standard_uploads <- function(ns) {
 create_standard_annotation_uploads <- function(ns) {
   shinyjs::hidden(div(
     id = ns(NAMESPACE_LOADPAGE$standard_annot_upload_panel),
-    h4("5. Upload annotation File", class = "icon-wrapper",
+    h4("Upload annotation File", class = "icon-wrapper",
        icon("question-circle", lib = "font-awesome"),
        div("Upload manually created annotation file. This file maps MS runs to experiment metadata (i.e. conditions, bioreplicates). Please see Help tab for information on creating this file.", class = "icon-tooltip")),
     fileInput(ns('annot'), "", multiple = FALSE, accept = c(".csv"))
@@ -258,17 +260,17 @@ create_msstats_uploads <- function(ns) {
     # Regular MSstats format
     shinyjs::hidden(div(
       id = ns(NAMESPACE_LOADPAGE$msstats_regular_upload_panel),
-      h4("4. Upload data in MSstats Format"),
+      h4("Upload data in MSstats Format"),
       fileInput(ns('msstatsdata'), "", multiple = FALSE, accept = NULL)
     )),
 
     # PTM MSstats format.
     shinyjs::hidden(div(
       id = ns(NAMESPACE_LOADPAGE$msstats_ptm_upload_panel),
-      h4("4. Upload PTM data in MSstats Format"),
+      h4("Upload PTM data in MSstats Format"),
       fileInput(ns('msstatsptmdata'), "", multiple = FALSE, accept = NULL),
 
-      h4("5. (Optional) Upload unmodified data in MSstats Format"),
+      h4("(Optional) Upload unmodified data in MSstats Format"),
       fileInput(ns('unmod'), "", multiple = FALSE, accept = NULL),
       tags$br()
     ))
@@ -280,7 +282,7 @@ create_msstats_uploads <- function(ns) {
 create_skyline_uploads <- function(ns) {
   shinyjs::hidden(div(
     id = ns(NAMESPACE_LOADPAGE$skyline_upload_panel),
-    h4("4. Upload MSstats report from Skyline"),
+    h4("Upload MSstats report from Skyline"),
     fileInput(ns('skylinedata'), "", multiple = FALSE, accept = NULL)
   ))
 }
@@ -330,7 +332,7 @@ create_diann_uploads <- function(ns) {
 #' Create DIANN header
 #' @noRd
 create_diann_header <- function() {
-  h4("4. Upload MSstats report from DIANN")
+  h4("Upload MSstats report from DIANN")
 }
 
 #' Create DIANN mode selector (Local only)
@@ -479,7 +481,7 @@ create_spectronaut_uploads <- function(ns) {
 #' Create Spectronaut header
 #' @noRd
 create_spectronaut_header <- function() {
-  h4("4. Upload MSstats scheme output from Spectronaut")
+  h4("Upload MSstats scheme output from Spectronaut")
 }
 
 #' Create Spectronaut mode selector (Local only)
@@ -642,16 +644,16 @@ create_spectronaut_anomaly_ui <- function(ns, calculate_anomaly_def = FALSE) {
 create_ptm_fragpipe_uploads <- function(ns) {
   shinyjs::hidden(div(
     id = ns(NAMESPACE_LOADPAGE$ptm_fragpipe_upload_panel),
-    h4("4. Upload PTM msstats dataset"),
+    h4("Upload PTM msstats dataset"),
     fileInput(ns('ptmdata'), "", multiple = FALSE, accept = NULL),
 
-    h4("5. Upload PTM annotation file"),
+    h4("Upload PTM annotation file"),
     fileInput(ns('annotation'), "", multiple = FALSE, accept = c(".csv")),
 
-    h4("6. Upload global profiling msstats dataset (optional)"),
+    h4("Upload global profiling msstats dataset (optional)"),
     fileInput(ns('globaldata'), "", multiple = FALSE, accept = NULL),
 
-    h4("7. Upload global profiling annotation file (optional)"),
+    h4("Upload global profiling annotation file (optional)"),
     fileInput(ns('globalannotation'), "", multiple = FALSE, accept = c(".csv")),
 
     h4("Select the options for pre-processing"),
@@ -680,13 +682,13 @@ create_ptm_fragpipe_uploads <- function(ns) {
 create_maxquant_uploads <- function(ns) {
   shinyjs::hidden(div(
     id = ns(NAMESPACE_LOADPAGE$maxquant_upload_panel),
-    h4("4. Upload evidence.txt File"),
+    h4("Upload evidence.txt File"),
     fileInput(ns('evidence'), "", multiple = FALSE, accept = NULL),
 
-    h4("5. Upload proteinGroups.txt File"),
+    h4("Upload proteinGroups.txt File"),
     fileInput(ns('pGroup'), "", multiple = FALSE, accept = NULL),
 
-    h4("6. Upload annotation File", class = "icon-wrapper",
+    h4("Upload annotation File", class = "icon-wrapper",
        icon("question-circle", lib = "font-awesome"),
        div("Upload manually created annotation file. This file maps MS runs to experiment metadata (i.e. conditions, bioreplicates). Please see Help tab for information on creating this file.", class = "icon-tooltip")),
     fileInput(ns('annot1'), "", multiple = FALSE, accept = c(".csv"))
@@ -736,34 +738,34 @@ create_ptm_uploads <- function(ns) {
   tagList(
     shinyjs::hidden(div(
       id = ns(NAMESPACE_LOADPAGE$ptm_uploads_panel),
-      h4("4. Upload PTM Input File"),
+      h4("Upload PTM Input File"),
       fileInput(ns('ptm_input'), "", multiple = FALSE, accept = NULL),
 
-      h4("5. Upload annotation File", class = "icon-wrapper",
+      h4("Upload annotation File", class = "icon-wrapper",
          icon("question-circle", lib = "font-awesome"),
          div("Upload manually created annotation file. This file maps MS runs to experiment metadata (i.e. conditions, bioreplicates). Please see Help tab for information on creating this file.", class = "icon-tooltip")),
       fileInput(ns('ptm_annot'), "", multiple = FALSE, accept = c(".csv")),
 
-      h4("6. Upload fasta File", class = "icon-wrapper",
+      h4("Upload fasta File", class = "icon-wrapper",
          icon("question-circle", lib = "font-awesome"),
          div("Upload FASTA file. This file allows us to identify where in the protein sequence a modification occurs.", class = "icon-tooltip")),
       fileInput(ns('fasta'), "", multiple = FALSE),
 
-      h4("7. (Recommended) Upload Unmodified Protein Input File"),
+      h4("(Recommended) Upload Unmodified Protein Input File"),
       fileInput(ns('ptm_protein_input'), "", multiple = FALSE, accept = NULL)
     )),
 
     # MaxQuant specific PTM
     shinyjs::hidden(div(
       id = ns(NAMESPACE_LOADPAGE$ptm_maxquant_pgroup_panel),
-      h4("8. (Optional) Upload Unmodified Protein proteinGroups.txt File"),
+      h4("(Optional) Upload Unmodified Protein proteinGroups.txt File"),
       fileInput(ns('ptm_pgroup'), "", multiple = FALSE, accept = NULL)
     )),
 
     # Metamorpheus specific PTM
     shinyjs::hidden(div(
       id = ns(NAMESPACE_LOADPAGE$ptm_metamorpheus_extras_panel),
-      h4("8. (Recommended) Upload Unmodified Protein Annotation File"),
+      h4("(Recommended) Upload Unmodified Protein Annotation File"),
       fileInput(
         ns("ptm_protein_annot"),
         "",
@@ -826,16 +828,16 @@ create_ptm_modification_labels <- function(ns) {
 create_ump_uploads <- function(ns) {
   shinyjs::hidden(div(
     id = ns(NAMESPACE_LOADPAGE$dia_umpire_upload_panel),
-    h4("4. Upload FragSummary.xls File"),
+    h4("Upload FragSummary.xls File"),
     fileInput(ns('fragSummary'), "", multiple = FALSE, accept = NULL),
 
-    h4("5. Upload PeptideSummary.xls File"),
+    h4("Upload PeptideSummary.xls File"),
     fileInput(ns('peptideSummary'), "", multiple = FALSE, accept = NULL),
 
-    h4("6. Upload ProtSummary.xls File"),
+    h4("Upload ProtSummary.xls File"),
     fileInput(ns('protSummary'), "", multiple = FALSE, accept = NULL),
 
-    h4("7. Upload Annotation File", class = "icon-wrapper",
+    h4("Upload Annotation File", class = "icon-wrapper",
        icon("question-circle", lib = "font-awesome"),
        div("Upload manually created annotation file. This file maps MS runs to experiment metadata (i.e. conditions, bioreplicates). Please see Help tab for information on creating this file.", class = "icon-tooltip")),
     fileInput(ns('annot2'), "", multiple = FALSE, accept = c(".csv"))

--- a/R/module-loadpage-ui.R
+++ b/R/module-loadpage-ui.R
@@ -36,8 +36,8 @@ loadpageUI <- function(id) {
         # Main selection controls
         create_main_selection_controls(ns),
         
-        tags$hr(),
-        
+        tags$hr(id = ns("main_selection_divider")),
+
         # Label-free type selection
         create_label_free_type_selection(ns),
         
@@ -136,7 +136,7 @@ create_main_selection_controls <- function(ns) {
   tagList(
     # Biological Question
     radioButtons(ns("BIO"),
-                 label = h4("1. Biological Question", class = "icon-wrapper", 
+                 label = h4("1. Biological Question", class = "icon-wrapper",
                              icon("question-circle", lib = "font-awesome"),
                              div("Select the biological question of interest.", class = "icon-tooltip")),
                  c("Protein"="Protein", "Peptide"="Peptide","PTM"="PTM")
@@ -144,7 +144,7 @@ create_main_selection_controls <- function(ns) {
     
     # Label Type
     radioButtons(ns("DDA_DIA"),
-                 label = h4("2. Label Type", class = "icon-wrapper", 
+                 label = h4("2. Label Type", class = "icon-wrapper",
                              icon("question-circle", lib = "font-awesome"),
                              div("Label-free will process all label-free acquisitions including DDA/DIA/SRM/PRM.", class = "icon-tooltip")),
                  c("Label-Free"="LType", "TMT"="TMT")
@@ -152,17 +152,8 @@ create_main_selection_controls <- function(ns) {
     
     # File Type
     radioButtons(ns("filetype"),
-                 label = h4("3. Type of File", class = "icon-wrapper", 
-                             icon("question-circle", lib = "font-awesome"),
-                             div("Choose the spectral processing tool used to process your data", class = "icon-tooltip")),
-                 choices = c("Example dataset" = "sample",
-                             "MSstats Format" = "msstats",
-                             "Skyline" = "sky", "MaxQuant" = "maxq",
-                             "Progenesis" = "prog", "Proteome Discoverer" = "PD",
-                             "OpenMS" = "openms", "Spectronaut" = "spec",
-                             "OpenSWATH" = "open", "DIA-Umpire" = "ump",
-                             "SpectroMine" = "spmin", "FragPipe" = "phil", "DIANN"="diann",
-                             "Metamorpheus" = "meta"),
+                 label = uiOutput(ns("filetype_header")),
+                 choices = LOADPAGE_FILETYPE_CHOICES,
                  selected = character(0)
     )
   )
@@ -214,6 +205,9 @@ create_file_upload_sections <- function(ns) {
     # DIA-Umpire uploads
     create_ump_uploads(ns),
     
+    # MZmine uploads (metabolomics)
+    create_mzmine_uploads(ns),
+
     # Standard annotation uploads
     create_standard_annotation_uploads(ns)
   )
@@ -272,6 +266,18 @@ create_skyline_uploads <- function(ns) {
     id = ns(NAMESPACE_LOADPAGE$skyline_upload_panel),
     h4("4. Upload MSstats report from Skyline"),
     fileInput(ns('skylinedata'), "", multiple = FALSE, accept = NULL)
+  ))
+}
+
+#' Create MZmine file uploads (metabolomics; visibility driven server-side).
+#' @noRd
+create_mzmine_uploads <- function(ns) {
+  shinyjs::hidden(div(
+    id = ns(NAMESPACE_LOADPAGE$mzmine_upload_panel),
+    fileInput(ns("mzmine_input"),       "MZmine feature quant table"),
+    fileInput(ns("mzmine_annotation"),  "Annotation file"),
+    fileInput(ns("mzmine_annotations"), "MZmine compound annotations"),
+    fileInput(ns("sirius_annotations"), "SIRIUS annotations (optional, recommended)")
   ))
 }
 

--- a/R/module-loadpage-ui.R
+++ b/R/module-loadpage-ui.R
@@ -36,7 +36,7 @@ loadpageUI <- function(id) {
         # Main selection controls
         create_main_selection_controls(ns),
         
-        tags$hr(id = ns("main_selection_divider")),
+        tags$hr(id = ns(NAMESPACE_LOADPAGE$main_selection_divider)),
 
         # Label-free type selection
         create_label_free_type_selection(ns),

--- a/R/utils.R
+++ b/R/utils.R
@@ -316,6 +316,24 @@ getData <- function(input) {
   if(is.null(input$filetype)) {
     return(NULL)
   }
+  # MZmine (metabolomics) is gated purely on the converter and handled here,
+  # before the BIO/DDA_DIA routing below, so a stale BIO/DDA_DIA carried over
+  # from a prior template cannot divert it into a PTM/TMT converter path. The
+  # early return also skips the BIO == "Peptide" post-processing that would
+  # otherwise overwrite the metabolite names.
+  if (input$filetype == "mzmine") {
+    mzmine_in    = data.table::fread(input$mzmine_input$datapath)
+    annot        = data.table::fread(input$mzmine_annotation$datapath)
+    mzmine_annot = data.table::fread(input$mzmine_annotations$datapath)
+    sirius_annot = if (!is.null(input$sirius_annotations))
+                     data.table::fread(input$sirius_annotations$datapath) else NULL
+    mydata = MSstatsConvert::MZMinetoMSstatsFormat(
+      input = mzmine_in, annotation = annot,
+      mzmine_annotations = mzmine_annot, sirius_annotations = sirius_annot,
+      use_log_file = FALSE)
+    remove_modal_spinner()
+    return(mydata)
+  }
   if(input$filetype == 'sample') {
     if(input$BIO != "PTM" && input$DDA_DIA =='LType' && input$LabelFreeType == "SRM_PRM") {
       mydata = MSstats::DDARawData
@@ -1090,6 +1108,24 @@ getData <- function(input) {
   return(mydata)
 }
 
+#' Display-only view of MSstats-format data for the metabolomics template.
+#'
+#' Returns a COPY with metabolomics-facing column names (ProteinName ->
+#' Metabolite, PeptideSequence -> Feature) and the charge/label columns
+#' dropped. Operates on `as.data.frame(data)`, so the underlying data.table
+#' that `getData()` returns and downstream pages consume is never mutated by
+#' reference.
+#' @noRd
+metabolomics_preview_view <- function(data) {
+  d = as.data.frame(data)
+  d = d[, !(names(d) %in% c("PrecursorCharge", "FragmentIon",
+                            "ProductCharge", "IsotopeLabelType")),
+        drop = FALSE]
+  names(d)[names(d) == "ProteinName"]     = "Metabolite"
+  names(d)[names(d) == "PeptideSequence"] = "Feature"
+  d
+}
+
 getDataCode <- function(input) {
   codes = ""
   codes = paste(codes, "\n# Load Packages
@@ -1464,6 +1500,16 @@ library(MSstatsPTM)\n", sep = "")
                                        removeProtein_with1Feature = ", input$remove, ",\n\t\t\t\t       ",
                       "use_log_file = FALSE)\n", sep = "")
       }
+    }
+    else if(input$filetype == 'mzmine') {
+      codes = paste(codes, "data = data.table::fread(\"insert your MZmine feature quant table filepath\")\nannot_file = data.table::fread(\"insert your annotation filepath\")\nmzmine_annotations = data.table::fread(\"insert your MZmine compound annotations filepath\")\n# Optional: set sirius_annotations = NULL if there is no SIRIUS data\nsirius_annotations = tryCatch(data.table::fread(\"insert your SIRIUS annotations filepath\"), error = function(e) NULL)\n"
+                    , sep = "")
+
+      codes = paste(codes, "data = MSstatsConvert::MZMinetoMSstatsFormat(input = data,
+                                       annotation = annot_file,
+                                       mzmine_annotations = mzmine_annotations,
+                                       sirius_annotations = sirius_annotations,
+                                       use_log_file = FALSE)\n", sep = "")
     }
     else if(input$filetype == 'open') {
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -322,15 +322,26 @@ getData <- function(input) {
   # early return also skips the BIO == "Peptide" post-processing that would
   # otherwise overwrite the metabolite names.
   if (input$filetype == "mzmine") {
-    mzmine_in    = data.table::fread(input$mzmine_input$datapath)
-    annot        = data.table::fread(input$mzmine_annotation$datapath)
-    mzmine_annot = data.table::fread(input$mzmine_annotations$datapath)
-    sirius_annot = if (!is.null(input$sirius_annotations))
-                     data.table::fread(input$sirius_annotations$datapath) else NULL
-    mydata = MSstatsConvert::MZMinetoMSstatsFormat(
-      input = mzmine_in, annotation = annot,
-      mzmine_annotations = mzmine_annot, sirius_annotations = sirius_annot,
-      use_log_file = FALSE)
+    mydata = tryCatch({
+      mzmine_in    = data.table::fread(input$mzmine_input$datapath)
+      annot        = data.table::fread(input$mzmine_annotation$datapath)
+      mzmine_annot = data.table::fread(input$mzmine_annotations$datapath)
+      sirius_annot = if (!is.null(input$sirius_annotations))
+                       data.table::fread(input$sirius_annotations$datapath) else NULL
+      MSstatsConvert::MZMinetoMSstatsFormat(
+        input = mzmine_in, annotation = annot,
+        mzmine_annotations = mzmine_annot, sirius_annotations = sirius_annot,
+        use_log_file = FALSE)
+    },
+    error = function(e) {
+      remove_modal_spinner()
+      showNotification(
+        paste("Failed to process MZmine data. Please check your input files:",
+              conditionMessage(e)),
+        type = "error", duration = 10)
+      return(NULL)
+    })
+    if (is.null(mydata)) return(NULL)
     remove_modal_spinner()
     return(mydata)
   }

--- a/tests/testthat/test-loadpage-server-rendering.R
+++ b/tests/testthat/test-loadpage-server-rendering.R
@@ -65,6 +65,15 @@ test_that("loadpage_show_mzmine_upload is TRUE only for the mzmine converter", {
   expect_false(MSstatsShiny:::loadpage_show_mzmine_upload(NULL))
 })
 
+test_that("LOADPAGE_METABOLOMICS_FILETYPE_CHOICES offers MZmine and MSstats Format", {
+  expect_equal(LOADPAGE_METABOLOMICS_FILETYPE_CHOICES,
+               c("MZmine" = "mzmine", "MSstats Format" = "msstats"))
+  expect_equal(names(LOADPAGE_METABOLOMICS_FILETYPE_CHOICES),
+               c("MZmine", "MSstats Format"))
+  expect_true(all(c("mzmine", "msstats") %in%
+                    LOADPAGE_METABOLOMICS_FILETYPE_CHOICES))
+})
+
 test_that("loadpage_show_diann_mbr requires both q_val and diann", {
   expect_true(MSstatsShiny:::loadpage_show_diann_mbr(TRUE, "diann"))
 

--- a/tests/testthat/test-loadpage-server-rendering.R
+++ b/tests/testthat/test-loadpage-server-rendering.R
@@ -56,6 +56,15 @@ test_that("loadpage_show_qval_cutoff is the q_val checkbox", {
   expect_false(MSstatsShiny:::loadpage_show_qval_cutoff(NULL))
 })
 
+test_that("loadpage_show_mzmine_upload is TRUE only for the mzmine converter", {
+  expect_true(MSstatsShiny:::loadpage_show_mzmine_upload("mzmine"))
+
+  expect_false(MSstatsShiny:::loadpage_show_mzmine_upload("diann"))
+  expect_false(MSstatsShiny:::loadpage_show_mzmine_upload("sky"))
+  expect_false(MSstatsShiny:::loadpage_show_mzmine_upload("sample"))
+  expect_false(MSstatsShiny:::loadpage_show_mzmine_upload(NULL))
+})
+
 test_that("loadpage_show_diann_mbr requires both q_val and diann", {
   expect_true(MSstatsShiny:::loadpage_show_diann_mbr(TRUE, "diann"))
 

--- a/tests/testthat/test-loadpage-server-rendering.R
+++ b/tests/testthat/test-loadpage-server-rendering.R
@@ -311,6 +311,11 @@ test_that("loadpage_show_label_free_options excludes sample + big-file paths", {
   # big-file DIANN excluded; small-file allowed
   expect_false(MSstatsShiny:::loadpage_show_label_free_options("diann", "LType", FALSE, TRUE))
   expect_true(MSstatsShiny:::loadpage_show_label_free_options("diann", "LType", FALSE, FALSE))
+  # metabolomics template suppresses the block (exclusion moved into the predicate)
+  expect_false(MSstatsShiny:::loadpage_show_label_free_options(
+    "sky", "LType", FALSE, FALSE, TEMPLATES$metabolomics))
+  expect_true(MSstatsShiny:::loadpage_show_label_free_options(
+    "sky", "LType", FALSE, FALSE, TEMPLATES$default))
 })
 
 test_that("loadpage_show_openswath_mscore is filetype == 'open'", {

--- a/tests/testthat/test-module-loadpage-ui.R
+++ b/tests/testthat/test-module-loadpage-ui.R
@@ -580,6 +580,18 @@ test_that("file inputs have proper accept attributes", {
   expect_true(grepl('accept=.*csv', annot_html))
 })
 
+test_that("create_mzmine_uploads renders the hidden panel and its four input ids", {
+  uploads_html <- as.character(create_mzmine_uploads(NS("test")))
+
+  # Hidden panel container (NAMESPACE_LOADPAGE$mzmine_upload_panel).
+  expect_true(grepl('id="test-mzmine_upload_panel"', uploads_html, fixed = TRUE))
+  # The four namespaced file-input ids that getData()/proceed validation read.
+  expect_true(grepl('id="test-mzmine_input"', uploads_html, fixed = TRUE))
+  expect_true(grepl('id="test-mzmine_annotation"', uploads_html, fixed = TRUE))
+  expect_true(grepl('id="test-mzmine_annotations"', uploads_html, fixed = TRUE))
+  expect_true(grepl('id="test-sirius_annotations"', uploads_html, fixed = TRUE))
+})
+
 # Tests for Spectronaut specific UI components
 test_that("create_spectronaut_uploads creates UI outputs", {
   uploads <- create_spectronaut_uploads(NS("test"))

--- a/tests/testthat/test-module-loadpage-ui.R
+++ b/tests/testthat/test-module-loadpage-ui.R
@@ -1,15 +1,29 @@
 test_that("loadpageUI returns a valid tagList with fluidPage structure", {
   # Test basic function execution and structure
   result <- loadpageUI("test")
-  
+
   # Should return a tagList
   expect_s3_class(result, "shiny.tag.list")
-  
+
   result_html = as.character(result)
   expect_true(grepl("div", result_html))
-  
+
   # Should not be NULL or empty
   expect_true(length(result) > 0)
+})
+
+test_that("metabolomics template is registered and appears in the picker choices", {
+  expect_equal(TEMPLATES$metabolomics, "metabolomics")
+  expect_equal(TEMPLATE_LABELS$metabolomics,
+               "Metabolite Differential Abundance Analysis")
+
+  # The home picker builds its choices from the constants via
+  # setNames(unlist(TEMPLATES), unlist(TEMPLATE_LABELS)).
+  choices = setNames(unlist(TEMPLATES, use.names = FALSE),
+                     unlist(TEMPLATE_LABELS, use.names = FALSE))
+  expect_true("metabolomics" %in% choices)
+  expect_equal(names(choices)[choices == "metabolomics"],
+               "Metabolite Differential Abundance Analysis")
 })
 
 test_that("loadpageUI generates correct namespaced input IDs", {
@@ -341,7 +355,9 @@ test_that("create_main_selection_controls creates proper radio buttons", {
   expect_true(grepl("TMT", controls_html))
   
   # Check for file type options
-  expect_true(grepl("Type of File", controls_html))
+  # The Type-of-File header is rendered server-side (uiOutput placeholder);
+  # its text/number/tooltip are covered by the loadpage_filetype_header test.
+  expect_true(grepl("filetype_header", controls_html))
   expect_true(grepl("MSstats Format", controls_html))
   expect_true(grepl("Skyline", controls_html))
   expect_true(grepl("MaxQuant", controls_html))
@@ -507,7 +523,7 @@ test_that("main selection controls maintain proper order", {
   # Find positions of each section
   bio_pos <- regexpr("Biological Question", controls_html)
   label_pos <- regexpr("Label Type", controls_html)
-  file_pos <- regexpr("Type of File", controls_html)
+  file_pos <- regexpr("filetype_header", controls_html)
   
   # Verify correct order
   expect_true(bio_pos < label_pos)
@@ -516,7 +532,7 @@ test_that("main selection controls maintain proper order", {
   # Verify numbered headings are in order
   expect_true(grepl("1\\. Biological Question", controls_html))
   expect_true(grepl("2\\. Label Type", controls_html))
-  expect_true(grepl("3\\. Type of File", controls_html))
+  # "3. Type of File" is server-rendered; see the loadpage_filetype_header test.
 })
 
 # Test tooltip content is preserved
@@ -527,11 +543,33 @@ test_that("tooltips contain proper explanatory text", {
   # Check for tooltip explanations
   expect_true(grepl("Select the biological question of interest", controls_html))
   expect_true(grepl("Label-free will process all label-free acquisitions", controls_html))
-  expect_true(grepl("Choose the spectral processing tool used", controls_html))
+  # The file-type tooltip is server-rendered; see the loadpage_filetype_header test.
   
   # Check for icon-wrapper and icon-tooltip classes
   expect_true(grepl("icon-wrapper", controls_html))
   expect_true(grepl("icon-tooltip", controls_html))
+})
+
+# The Type-of-File header renders server-side (uiOutput -> output$filetype_header)
+# via loadpage_filetype_header(); verify its number/tooltip behavior here.
+test_that("loadpage_filetype_header numbers the header except under metabolomics", {
+  # Non-metabolomics templates: numbered "3. Type of File" with the tooltip.
+  default_html <- as.character(
+    MSstatsShiny:::loadpage_filetype_header(TEMPLATES$default))
+  expect_true(grepl("3\\. Type of File", default_html))
+  expect_true(grepl("Choose the spectral processing tool used", default_html))
+  expect_true(grepl("icon-tooltip", default_html))
+
+  # NULL template (before any selection) is also numbered.
+  expect_true(grepl("3\\. Type of File",
+                    as.character(MSstatsShiny:::loadpage_filetype_header(NULL))))
+
+  # Metabolomics: no number, still reads "Type of File", tooltip preserved.
+  metab_html <- as.character(
+    MSstatsShiny:::loadpage_filetype_header(TEMPLATES$metabolomics))
+  expect_true(grepl("Type of File", metab_html))
+  expect_false(grepl("3\\. Type of File", metab_html))
+  expect_true(grepl("Choose the spectral processing tool used", metab_html))
 })
 
 # Test file input configurations

--- a/tests/testthat/test-module-loadpage-ui.R
+++ b/tests/testthat/test-module-loadpage-ui.R
@@ -239,13 +239,12 @@ test_that("loadpageUI properly handles file input elements and validation", {
   expect_true(grepl("proceed1", html_output),
               "Upload button not found")
   
-  # Should include help text and external links
-  expect_true(grepl("User Guide", html_output),
-              "Help documentation links not found")
-  
-  # Should include file size warnings
-  expect_true(grepl("250 MB", html_output),
-              "File size limit warning not found")
+  # The upload description renders server-side now (output$upload_description
+  # fills this uiOutput slot; see STEP 3). The static UI carries only the
+  # placeholder; the "User Guide" / "250 MB" text is asserted directly against
+  # create_header_content() below.
+  expect_true(grepl('id="test-upload_description"', html_output, fixed = TRUE),
+              "Upload-description uiOutput slot not found")
 })
 
 # Test suite for loadpage UI module
@@ -274,6 +273,21 @@ test_that("create_header_content includes required elements", {
   expect_true(grepl("msstats.org", header_html))
   expect_true(grepl("bioconductor.org", header_html))
   expect_true(grepl('target="_blank"', header_html))
+})
+
+# Tests for create_metabolomics_header_content()
+test_that("create_metabolomics_header_content includes metabolomics-specific text", {
+  header <- create_metabolomics_header_content()
+  header_html <- as.character(header)
+
+  # The metabolomics renderUI branch (output$upload_description) renders this.
+  expect_true(grepl("metabolomics pipeline", header_html))
+  expect_true(grepl("MZmine feature quant", header_html))
+  expect_true(grepl("SIRIUS", header_html))
+  expect_true(grepl("MSstats format", header_html))
+  # Keeps the CSV/TSV + size note.
+  expect_true(grepl("CSV/TSV", header_html))
+  expect_true(grepl("250 MB", header_html))
 })
 
 # Tests for create_sample_dataset_descriptions()
@@ -580,7 +594,7 @@ test_that("file inputs have proper accept attributes", {
   expect_true(grepl('accept=.*csv', annot_html))
 })
 
-test_that("create_mzmine_uploads renders the hidden panel and its four input ids", {
+test_that("create_mzmine_uploads renders the hidden panel, four input ids, and tooltips", {
   uploads_html <- as.character(create_mzmine_uploads(NS("test")))
 
   # Hidden panel container (NAMESPACE_LOADPAGE$mzmine_upload_panel).
@@ -590,6 +604,12 @@ test_that("create_mzmine_uploads renders the hidden panel and its four input ids
   expect_true(grepl('id="test-mzmine_annotation"', uploads_html, fixed = TRUE))
   expect_true(grepl('id="test-mzmine_annotations"', uploads_html, fixed = TRUE))
   expect_true(grepl('id="test-sirius_annotations"', uploads_html, fixed = TRUE))
+
+  # Fields carry help tooltips (icon-wrapper + icon-tooltip markup) and the
+  # visible label text survives being wrapped in the h5 tooltip container.
+  expect_true(grepl("icon-tooltip", uploads_html, fixed = TRUE))
+  expect_true(grepl("MZmine feature quant table", uploads_html, fixed = TRUE))
+  expect_true(grepl("SIRIUS structure identifications", uploads_html, fixed = TRUE))
 })
 
 # Tests for Spectronaut specific UI components

--- a/tests/testthat/test-module-loadpage-ui.R
+++ b/tests/testthat/test-module-loadpage-ui.R
@@ -369,9 +369,8 @@ test_that("create_main_selection_controls creates proper radio buttons", {
   expect_true(grepl("TMT", controls_html))
   
   # Check for file type options
-  # The Type-of-File header is rendered server-side (uiOutput placeholder);
-  # its text/number/tooltip are covered by the loadpage_filetype_header test.
-  expect_true(grepl("filetype_header", controls_html))
+  # The "Type of File" header is a static h4 (no template-dependent numbering).
+  expect_true(grepl("Type of File", controls_html))
   expect_true(grepl("MSstats Format", controls_html))
   expect_true(grepl("Skyline", controls_html))
   expect_true(grepl("MaxQuant", controls_html))
@@ -537,16 +536,16 @@ test_that("main selection controls maintain proper order", {
   # Find positions of each section
   bio_pos <- regexpr("Biological Question", controls_html)
   label_pos <- regexpr("Label Type", controls_html)
-  file_pos <- regexpr("filetype_header", controls_html)
-  
+  file_pos <- regexpr("Type of File", controls_html)
+
   # Verify correct order
   expect_true(bio_pos < label_pos)
   expect_true(label_pos < file_pos)
-  
-  # Verify numbered headings are in order
-  expect_true(grepl("1\\. Biological Question", controls_html))
-  expect_true(grepl("2\\. Label Type", controls_html))
-  # "3. Type of File" is server-rendered; see the loadpage_filetype_header test.
+
+  # Headers are present (section numbering was removed per review).
+  expect_true(grepl("Biological Question", controls_html))
+  expect_true(grepl("Label Type", controls_html))
+  expect_true(grepl("Type of File", controls_html))
 })
 
 # Test tooltip content is preserved
@@ -557,33 +556,11 @@ test_that("tooltips contain proper explanatory text", {
   # Check for tooltip explanations
   expect_true(grepl("Select the biological question of interest", controls_html))
   expect_true(grepl("Label-free will process all label-free acquisitions", controls_html))
-  # The file-type tooltip is server-rendered; see the loadpage_filetype_header test.
+  expect_true(grepl("Choose the spectral processing tool used", controls_html))
   
   # Check for icon-wrapper and icon-tooltip classes
   expect_true(grepl("icon-wrapper", controls_html))
   expect_true(grepl("icon-tooltip", controls_html))
-})
-
-# The Type-of-File header renders server-side (uiOutput -> output$filetype_header)
-# via loadpage_filetype_header(); verify its number/tooltip behavior here.
-test_that("loadpage_filetype_header numbers the header except under metabolomics", {
-  # Non-metabolomics templates: numbered "3. Type of File" with the tooltip.
-  default_html <- as.character(
-    MSstatsShiny:::loadpage_filetype_header(TEMPLATES$default))
-  expect_true(grepl("3\\. Type of File", default_html))
-  expect_true(grepl("Choose the spectral processing tool used", default_html))
-  expect_true(grepl("icon-tooltip", default_html))
-
-  # NULL template (before any selection) is also numbered.
-  expect_true(grepl("3\\. Type of File",
-                    as.character(MSstatsShiny:::loadpage_filetype_header(NULL))))
-
-  # Metabolomics: no number, still reads "Type of File", tooltip preserved.
-  metab_html <- as.character(
-    MSstatsShiny:::loadpage_filetype_header(TEMPLATES$metabolomics))
-  expect_true(grepl("Type of File", metab_html))
-  expect_false(grepl("3\\. Type of File", metab_html))
-  expect_true(grepl("Choose the spectral processing tool used", metab_html))
 })
 
 # Test file input configurations

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,6 +1,41 @@
 library(testthat)
 library(mockery)
 
+test_that("metabolomics_preview_view renames/drops for display without mutating input", {
+  input_dt = data.table::data.table(
+    ProteinName      = c("Glucose", "Alanine"),
+    PeptideSequence  = c("feature_1", "feature_2"),
+    PrecursorCharge  = NA_integer_,
+    FragmentIon      = NA_character_,
+    ProductCharge    = NA_integer_,
+    IsotopeLabelType = c("L", "L"),
+    Condition        = c("ctrl", "case"),
+    BioReplicate     = c(1, 2),
+    Run              = c("run_1", "run_2"),
+    Intensity        = c(100, 200)
+  )
+  before = colnames(input_dt)
+
+  view = MSstatsShiny:::metabolomics_preview_view(input_dt)
+
+  # ProteinName -> Metabolite, PeptideSequence -> Feature, charge/label columns
+  # dropped. Column order follows the input (standard MSstats order has
+  # Condition before BioReplicate), so assert the set rather than the sequence.
+  expect_setequal(colnames(view),
+                  c("Metabolite", "Feature", "BioReplicate",
+                    "Condition", "Run", "Intensity"))
+  expect_false(any(c("PrecursorCharge", "FragmentIon", "ProductCharge",
+                     "IsotopeLabelType") %in% colnames(view)))
+  expect_true(all(c("Metabolite", "Feature") %in% colnames(view)))
+
+  # Mutation guard: the input data.table is untouched (no by-reference edits).
+  expect_identical(colnames(input_dt), before)
+  expect_true(all(c("ProteinName", "PeptideSequence", "PrecursorCharge",
+                    "FragmentIon", "ProductCharge", "IsotopeLabelType")
+                  %in% colnames(input_dt)))
+  expect_s3_class(input_dt, "data.table")
+})
+
 test_that(".anomaly_scores_enabled ORs all three loadpage checkboxes", {
   # Spectronaut
   expect_true(MSstatsShiny:::.anomaly_scores_enabled(

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -28,6 +28,11 @@ test_that("metabolomics_preview_view renames/drops for display without mutating 
                      "IsotopeLabelType") %in% colnames(view)))
   expect_true(all(c("Metabolite", "Feature") %in% colnames(view)))
 
+  # The view is a plain data.frame by design (as.data.frame decouples it from
+  # the input data.table); it is intentionally NOT a data.table.
+  expect_s3_class(view, "data.frame")
+  expect_false(inherits(view, "data.table"))
+
   # Mutation guard: the input data.table is untouched (no by-reference edits).
   expect_identical(colnames(input_dt), before)
   expect_true(all(c("ProteinName", "PeptideSequence", "PrecursorCharge",

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -41,6 +41,42 @@ test_that("metabolomics_preview_view renames/drops for display without mutating 
   expect_s3_class(input_dt, "data.table")
 })
 
+test_that("metabolomics_summary2_view relabels metabolite rows and drops the redundant ones", {
+  # Mimic getSummary2()'s non-PTM output: a 2-column (label, value) frame in the
+  # order getSummary2 emits. Rows 2 ("Number of Peptides") and 3 ("Number of
+  # Features") hold the SAME value for real metabolomics data; they are given
+  # distinct values here so the assertions pin the drop-before-rename ordering.
+  summary2 = data.frame(
+    label = c("Number of Proteins", "Number of Peptides", "Number of Features",
+              "Number of Peptides/Protein", "Number of Features/Peptide",
+              "Intensity Range"),
+    value = c("142", "318", "999", "1 - 6", "1 - 1", "8200 - 51000000"),
+    stringsAsFactors = FALSE
+  )
+  colnames(summary2) = c("", "")   # getSummary2 blanks both column names
+
+  view = MSstatsShiny:::metabolomics_summary2_view(summary2)
+
+  # Exactly the four metabolite rows, in the original order.
+  expect_equal(as.character(view[[1]]),
+               c("Number of Metabolites", "Number of Features",
+                 "Number of Features/Metabolite", "Intensity Range"))
+
+  # Drop-before-rename: "Number of Features" survives with the old
+  # "Number of Peptides" value (318, row 2). A rename-first implementation would
+  # have produced two "Number of Features" rows and dropped both.
+  expect_equal(view[[2]][view[[1]] == "Number of Features"], "318")
+  expect_equal(view[[2]][view[[1]] == "Number of Metabolites"], "142")
+  expect_equal(view[[2]][view[[1]] == "Number of Features/Metabolite"], "1 - 6")
+  expect_equal(view[[2]][view[[1]] == "Intensity Range"], "8200 - 51000000")
+
+  # The redundant distinct-FEATURES count (999) and the always-1-1 ratio
+  # are both gone.
+  expect_false("999" %in% as.character(view[[2]]))
+  expect_false("1 - 1" %in% as.character(view[[2]]))
+  expect_equal(nrow(view), 4L)
+})
+
 test_that(".anomaly_scores_enabled ORs all three loadpage checkboxes", {
   # Spectronaut
   expect_true(MSstatsShiny:::.anomaly_scores_enabled(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation and Context
This PR adds a metabolomics-specific loadpage workflow to support data converted from **MZmine**. It introduces a `metabolomics` analysis template that reconfigures the loadpage UI (showing only metabolomics-relevant inputs), restricts filetype options to MZmine, validates required MZmine uploads, converts uploaded MZmine tables into MSstats format, and renders metabolomics-specific previews/summaries with metabolite/feature terminology.

## Changes
- **New templates/constants (core wiring)**
  - Extended `TEMPLATES` and `TEMPLATE_LABELS` with:
    - `metabolomics`
    - (and updated `protein_turnover` labels)
  - Added loadpage UI constants to `NAMESPACE_LOADPAGE`:
    - `tmt_options_ui`
    - `mzmine_upload_panel`
    - `main_selection_divider`
  - Added exported filetype choice constants:
    - `LOADPAGE_FILETYPE_CHOICES`
    - `LOADPAGE_METABOLOMICS_FILETYPE_CHOICES`

- **Metabolomics/MZmine-specific loadpage UI and visibility**
  - Added `loadpage_show_mzmine_upload(filetype)` to control visibility of the MZmine upload panel (enabled only for `filetype == "mzmine"`).
  - Updated `loadpage_show_label_free_options(...)` to suppress label-free options under the metabolomics template.
  - Extended `register_loadpage_visibility_observers(input, output, session, app_template = NULL)` with template-aware behavior:
    - When `app_template` is metabolomics:
      - hides BIO and DDA_DIA radios
      - hides `main_selection_divider`
      - resets BIO/DDA_DIA to defaults (`"Protein"` / `"LType"`)
      - updates `output$upload_description` to metabolomics-specific content
      - restricts filetype radio choices to MZmine-only
    - Observes `filetype` to show/hide `mzmine_upload_panel`.
  - Tightened the label-free options panel observer to pass `app_template`.
  - Removed BIO-driven show/hide observers for post-`proceed1` summary panels, shifting that behavior to summary rendering.

- **Loadpage proceed validation (MZmine gating)**
  - Updated `register_loadpage_proceed_validation()` so `proceed1` is enabled for `filetype == "mzmine"` only when these are all non-`NULL`:
    - `input$mzmine_input`
    - `input$mzmine_annotation`
    - `input$mzmine_annotations`
  - This MZmine branch is prioritized ahead of existing BIO/DDA_DIA gating.

- **Metabolomics preview and summary rendering**
  - Added `metabolomics_summary2_view(summary2)` to drop metabolomics-redundant rows and relabel remaining ones to metabolomics terminology.
  - Updated `register_loadpage_summary()`:
    - `output$summary` uses `head(metabolomics_preview_view(d))` for metabolomics template
    - `output$summary2` uses `metabolomics_summary2_view()` for metabolomics template
    - refactored “Top 6 rows” preview rendering to conditionally include panels directly in `renderUI` (instead of wrapping in always-present hidden containers).

- **MZmine conversion logic**
  - Updated `getData()` with an early `input$filetype == "mzmine"` branch:
    - reads MZmine feature quant table + annotation(s) + compound annotations (+ optional SIRIUS)
    - converts via `MSstatsConvert::MZMinetoMSstatsFormat()`
    - returns immediately (skipping BIO/DDA_DIA routing and BIO==`"Peptide"` post-processing).
  - Updated `getDataCode()` to generate a matching `filetype == 'mzmine'` code path (including optional SIRIUS).

- **Module wiring and UI refactor**
  - Updated `loadpageServer()` to forward `app_template` into `register_loadpage_visibility_observers(..., app_template = app_template)`.
  - Updated `loadpageUI()`:
    - switched to `uiOutput(ns("upload_description"))` for upload guidance
    - added an explicitly `id`’d, namespaced `hr` for `main_selection_divider`
    - changed “File Type” header rendering to `uiOutput(ns("filetype_header"))` backed by `LOADPAGE_FILETYPE_CHOICES`
    - inserted a hidden metabolomics MZmine upload panel before other annotation uploads
    - added `create_metabolomics_header_content()` and `create_mzmine_uploads(ns)` (namespaced inputs for MZmine quant table, annotations, compound annotations, optional SIRIUS).

- **DESCRIPTION**
  - Added `Remotes: r-lib/log4r`.

## Unit Tests
- `tests/testthat/test-loadpage-server-rendering.R`
  - Added truth-table test for `loadpage_show_mzmine_upload()` (only `converter/filetype == "mzmine"` yields `TRUE`).
  - Added exact-expected-value test for `LOADPAGE_METABOLOMICS_FILETYPE_CHOICES`.
  - Updated label-free options visibility expectations for metabolomics template suppression.

- `tests/testthat/test-module-loadpage-ui.R`
  - Added checks that `metabolomics` is registered in `TEMPLATES` with expected `TEMPLATE_LABELS`, and is present in home picker mapping.
  - Updated UI test expectations to use server-rendered `upload_description` (`uiOutput`) placeholder.
  - Added tests for `create_metabolomics_header_content()`.
  - Added dedicated tests for `create_mzmine_uploads(ns)` (hidden panel rendering, expected namespaced file-input IDs, and key tooltip/label markup).

- `tests/testthat/test-utils.R`
  - Added tests for `metabolomics_preview_view()`:
    - renames `ProteinName`→`Metabolite`, `PeptideSequence`→`Feature`
    - drops charge/label-related columns
    - returns a `data.frame` and does not mutate the input `data.table`.
  - Added tests for `metabolomics_summary2_view()`:
    - verifies relabeling and removal of redundant rows/records.

## Coding Guidelines Violated
- `R/utils.R` contains a `# TODO: This code stops processing if a file is not uploaded correctly.` comment (TODO marker present at/around line 579).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->