### PR TITLE
fix protein turnover download zipfile

### DIFF
--- a/R/module-statmodel-server.R
+++ b/R/module-statmodel-server.R
@@ -463,7 +463,7 @@ statmodelServer = function(id, parent_session, loadpage_input, qc_input,
       create_download_handlers(output, data_comparison, SignificantProteins,
                                data_comparison_code)
       create_ptm_download_handlers(output, data_comparison, SignificantProteins)
-      create_download_plot_handler(output, input, contrast, preprocess_data, data_comparison, loadpage_input, app_template, condition_metadata)
+      create_download_plot_handler(output, input, contrast, preprocess_data, data_comparison, loadpage_input, app_template, turnover_ratios, condition_metadata)
       
       # Plot rendering
       output[[NAMESPACE_STATMODEL$visualization_plot_output]] = renderUI({

--- a/R/statmodel-server-visualization.R
+++ b/R/statmodel-server-visualization.R
@@ -214,7 +214,7 @@ zip_and_copy_plot <- function(pdf_files, dest_file) {
 
 #' @importFrom ggplot2 ggsave
 #' @importFrom utils zip
-create_download_plot_handler <- function(output, input, contrast, preprocess_data, data_comparison, loadpage_input, app_template = reactive(TEMPLATES$default), condition_metadata = reactive(NULL)) {
+create_download_plot_handler <- function(output, input, contrast, preprocess_data, data_comparison, loadpage_input, app_template = reactive(TEMPLATES$default), turnover_ratios = reactive(NULL), condition_metadata = reactive(NULL)) {
   output[[NAMESPACE_STATMODEL$visualization_download_plot_results]] <- downloadHandler(
     filename = function() {
       get_download_plot_filename(input[[NAMESPACE_STATMODEL$visualization_plot_type]])

--- a/tests/testthat/test-module-statmodel-server.R
+++ b/tests/testthat/test-module-statmodel-server.R
@@ -781,8 +781,8 @@ test_that("create_download_plot_handler is invoked with all 6 arguments", {
     {
       expect_true(handler_called,
                   info = "create_download_plot_handler should be called during server init")
-      expect_equal(length(handler_args), 8,
-                   info = "create_download_plot_handler should receive 6 arguments")
+      expect_equal(length(handler_args), 9,
+                   info = "create_download_plot_handler should receive 9 arguments")
     }
   )
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

Protein turnover plot downloads lacked the `turnover_ratios` reactive required by response-curve templates, causing zipfile download behavior to fail. The download handler now receives this reactive explicitly.

## Changes

- Added `turnover_ratios` to `create_download_plot_handler()` as an optional reactive argument.
- Passed `turnover_ratios` from `statmodelServer` into the download handler.
- Preserved a `reactive(NULL)` default for compatibility.
- Updated the initialization test to expect nine handler arguments.

## Unit Tests

- Modified `test-module-statmodel-server.R` to verify the updated nine-argument handler initialization.

## Coding Guidelines

- No coding guideline violations identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->