### PR TITLE
Add Data Upload tab to QC page for pre-processed data (default template)

### DIFF
--- a/R/constants.R
+++ b/R/constants.R
@@ -185,7 +185,10 @@ NAMESPACE_QC = list(
   profileplot_options_panel = "profileplot_options_panel",
   qualitymetrics_options_panel = "qualitymetrics_options_panel",
   nonptm_downloads_panel = "nonptm_downloads_panel",
-  ptm_downloads_panel = "ptm_downloads_panel"
+  ptm_downloads_panel = "ptm_downloads_panel",
+  # Data Upload tab template-gated upload panels
+  data_upload_mapping_panel = "data_upload_mapping_panel",
+  data_upload_ratios_panel = "data_upload_ratios_panel"
 )
 
 NAMESPACE_EXPDES = list(

--- a/R/module-qc-server.R
+++ b/R/module-qc-server.R
@@ -25,9 +25,6 @@ qcServer <- function(input, output, session, parent_session, loadpage_input, get
     preprocessData(input, loadpage_input(), get_data())
   })
 
-  # ---- Turnover ratios + Data Upload (registered before the QC consumers below
-  #      so the QC tabs read the effective, upload-aware data) ----
-
   turnover_ratios <- register_qc_turnover(input, output, session, app_template, get_data,
                                           get_condition_metadata, preprocess_data)
 
@@ -37,9 +34,7 @@ qcServer <- function(input, output, session, parent_session, loadpage_input, get
 
   effective_preprocess_data <- data_upload$effective_preprocess_data
 
-  # For protein turnover, re-level GROUP factor using TimeVal ordering from the
-  # condition metadata. Built from the effective (computed OR uploaded) data so
-  # the QC plots work on the upload path too.
+  # Re-level GROUP by TimeVal order for protein turnover.
   ordered_preprocess_data <- reactive({
     data <- effective_preprocess_data()
     if (is.null(data)) return(data)

--- a/R/module-qc-server.R
+++ b/R/module-qc-server.R
@@ -87,13 +87,14 @@ qcServer <- function(input, output, session, parent_session, loadpage_input, get
                                           get_condition_metadata, preprocess_data)
 
   data_upload = register_qc_data_upload(input, output, session, loadpage_input,
-                                        app_template, get_data, preprocess_data)
+                                        app_template, get_data, preprocess_data,
+                                        get_condition_metadata, turnover_ratios)
 
   return(
     list(
       input = input,
       preprocessData = data_upload$effective_preprocess_data,
-      turnoverRatios = turnover_ratios
+      turnoverRatios = data_upload$effective_turnover_ratios
     )
   )
 }

--- a/R/module-qc-server.R
+++ b/R/module-qc-server.R
@@ -25,9 +25,23 @@ qcServer <- function(input, output, session, parent_session, loadpage_input, get
     preprocessData(input, loadpage_input(), get_data())
   })
 
-  # For protein turnover, re-level GROUP factor using TimeVal ordering from loadpage
+  # ---- Turnover ratios + Data Upload (registered before the QC consumers below
+  #      so the QC tabs read the effective, upload-aware data) ----
+
+  turnover_ratios <- register_qc_turnover(input, output, session, app_template, get_data,
+                                          get_condition_metadata, preprocess_data)
+
+  data_upload = register_qc_data_upload(input, output, session, loadpage_input,
+                                        app_template, get_data, preprocess_data,
+                                        get_condition_metadata, turnover_ratios)
+
+  effective_preprocess_data <- data_upload$effective_preprocess_data
+
+  # For protein turnover, re-level GROUP factor using TimeVal ordering from the
+  # condition metadata. Built from the effective (computed OR uploaded) data so
+  # the QC plots work on the upload path too.
   ordered_preprocess_data <- reactive({
-    data <- preprocess_data()
+    data <- effective_preprocess_data()
     if (is.null(data)) return(data)
     if (!is.null(get_condition_metadata) && !is.null(get_condition_metadata())) {
       meta <- get_condition_metadata()
@@ -47,25 +61,15 @@ qcServer <- function(input, output, session, parent_session, loadpage_input, get
     data
   })
 
-  # ---- Turnover ratios + Data Upload (registered early so the navigation below
-  #      can key off the effective, upload-aware data) ----
-
-  turnover_ratios <- register_qc_turnover(input, output, session, app_template, get_data,
-                                          get_condition_metadata, preprocess_data)
-
-  data_upload = register_qc_data_upload(input, output, session, loadpage_input,
-                                        app_template, get_data, preprocess_data,
-                                        get_condition_metadata, turnover_ratios)
-
   # ---- Run caption and "Next step" navigation to the statistical model page ----
   # Keyed on the effective (computed OR uploaded) data so upload users, who never
   # fire input$run, still get the caption and the Next-step button.
 
-  cap = eventReactive(data_upload$effective_preprocess_data(), {
+  cap = eventReactive(effective_preprocess_data(), {
     text_output = "Data is ready. Click 'Next step' to continue to statistical modeling."
   })
 
-  observeEvent(data_upload$effective_preprocess_data(), {
+  observeEvent(effective_preprocess_data(), {
     output$submit.button = renderUI({
       ns <- session$ns
       actionButton(inputId = ns("proceed6"),label = "Next step")
@@ -77,7 +81,7 @@ qcServer <- function(input, output, session, parent_session, loadpage_input, get
   })
 
   enable("proceed6")
-  observeEvent(preprocess_data(),{
+  observeEvent(effective_preprocess_data(),{
     enable("proceed6")
   })
 
@@ -90,14 +94,14 @@ qcServer <- function(input, output, session, parent_session, loadpage_input, get
   register_qc_visibility_observers(input, session, loadpage_input, app_template)
   register_qc_sidebar_options(input, output, session, loadpage_input, get_data, app_template)
   register_qc_plots(input, output, session, loadpage_input, get_data,
-                    preprocess_data, ordered_preprocess_data)
-  register_qc_summary(input, output, session, loadpage_input, preprocess_data, app_template)
-  register_qc_downloads(input, output, session, loadpage_input, preprocess_data)
+                    effective_preprocess_data, ordered_preprocess_data)
+  register_qc_summary(input, output, session, loadpage_input, effective_preprocess_data, app_template)
+  register_qc_downloads(input, output, session, loadpage_input, effective_preprocess_data)
 
   return(
     list(
       input = input,
-      preprocessData = data_upload$effective_preprocess_data,
+      preprocessData = effective_preprocess_data,
       turnoverRatios = data_upload$effective_turnover_ratios
     )
   )

--- a/R/module-qc-server.R
+++ b/R/module-qc-server.R
@@ -66,7 +66,7 @@ qcServer <- function(input, output, session, parent_session, loadpage_input, get
   # fire input$run, still get the caption and the Next-step button.
 
   cap = eventReactive(effective_preprocess_data(), {
-    text_output = "Data is ready. Click 'Next step' to continue to statistical modeling."
+    text_output = "Data is ready. Click 'Next step' to continue to the Statistical Inference Page."
   })
 
   observeEvent(effective_preprocess_data(), {

--- a/R/module-qc-server.R
+++ b/R/module-qc-server.R
@@ -47,20 +47,30 @@ qcServer <- function(input, output, session, parent_session, loadpage_input, get
     data
   })
 
-  # ---- Run caption and "Next step" navigation to the statistical model page ----
+  # ---- Turnover ratios + Data Upload (registered early so the navigation below
+  #      can key off the effective, upload-aware data) ----
 
-  cap = eventReactive(input$run, {
-    text_output = "Protein abundance have been estimated, use the tabs below to download and plot the results."
+  turnover_ratios <- register_qc_turnover(input, output, session, app_template, get_data,
+                                          get_condition_metadata, preprocess_data)
+
+  data_upload = register_qc_data_upload(input, output, session, loadpage_input,
+                                        app_template, get_data, preprocess_data,
+                                        get_condition_metadata, turnover_ratios)
+
+  # ---- Run caption and "Next step" navigation to the statistical model page ----
+  # Keyed on the effective (computed OR uploaded) data so upload users, who never
+  # fire input$run, still get the caption and the Next-step button.
+
+  cap = eventReactive(data_upload$effective_preprocess_data(), {
+    text_output = "Data is ready. Click 'Next step' to continue to statistical modeling."
   })
 
-  observeEvent(input$run, {
+  observeEvent(data_upload$effective_preprocess_data(), {
     output$submit.button = renderUI({
       ns <- session$ns
       actionButton(inputId = ns("proceed6"),label = "Next step")
     })
-
-
-    })
+  }, ignoreNULL = TRUE)
 
   output$caption = renderText({
     cap()
@@ -83,12 +93,6 @@ qcServer <- function(input, output, session, parent_session, loadpage_input, get
                     preprocess_data, ordered_preprocess_data)
   register_qc_summary(input, output, session, loadpage_input, preprocess_data, app_template)
   register_qc_downloads(input, output, session, loadpage_input, preprocess_data)
-  turnover_ratios <- register_qc_turnover(input, output, session, app_template, get_data,
-                                          get_condition_metadata, preprocess_data)
-
-  data_upload = register_qc_data_upload(input, output, session, loadpage_input,
-                                        app_template, get_data, preprocess_data,
-                                        get_condition_metadata, turnover_ratios)
 
   return(
     list(

--- a/R/module-qc-server.R
+++ b/R/module-qc-server.R
@@ -86,10 +86,13 @@ qcServer <- function(input, output, session, parent_session, loadpage_input, get
   turnover_ratios <- register_qc_turnover(input, output, session, app_template, get_data,
                                           get_condition_metadata, preprocess_data)
 
+  data_upload = register_qc_data_upload(input, output, session, loadpage_input,
+                                        app_template, get_data, preprocess_data)
+
   return(
     list(
       input = input,
-      preprocessData = preprocess_data,
+      preprocessData = data_upload$effective_preprocess_data,
       turnoverRatios = turnover_ratios
     )
   )

--- a/R/module-qc-ui.R
+++ b/R/module-qc-ui.R
@@ -201,14 +201,15 @@ qcUI <- function(id) {
                  tabPanel("Data Upload",
                           wellPanel(
                             h4("Upload pre-processed data"),
-                            p("Bring FeatureLevelData and ProteinLevelData that were summarized in a previous session or an external pipeline. When both files are uploaded and the load page has not been used, the statistical analysis page uses them directly, skipping load-page conversion and summarization."),
+                            p("Bring FeatureLevelData and ProteinLevelData that were summarized in a previous session or an external pipeline. When the required files are uploaded and the load page has not been used, the statistical analysis page uses them directly, skipping load-page conversion and summarization."),
                             fileInput(ns("upload_feature_level"), "Upload FeatureLevelData (CSV)", accept = ".csv"),
                             fileInput(ns("upload_protein_level"), "Upload ProteinLevelData (CSV)", accept = ".csv"),
                             p(tags$strong("Required columns (names must match exactly, case-sensitive):")),
                             tags$ul(
                               tags$li(tags$strong("FeatureLevelData: "), "PROTEIN, PEPTIDE, FEATURE, RUN, GROUP, LABEL, INTENSITY"),
-                              tags$li(tags$strong("ProteinLevelData: "), "Protein, GROUP, RUN, LogIntensities")
+                              tags$li(tags$strong("ProteinLevelData: "), "Protein, GROUP, RUN, LogIntensities (add LABEL for protein turnover)")
                             ),
+                            p(tags$em("For protein turnover, FeatureLevelData is optional; upload ProteinLevelData (with LABEL), the turnover ratios, and the GROUP mapping. Other templates require both FeatureLevelData and ProteinLevelData.")),
                             # Template-gated (turnover + chemo): GROUP mapping, shown/hidden server-side
                             shinyjs::hidden(div(
                               id = ns(NAMESPACE_QC$data_upload_mapping_panel),
@@ -222,7 +223,7 @@ qcUI <- function(id) {
                               p(tags$strong("Required columns:")),
                               tags$ul(
                                 tags$li(tags$strong("Protein turnover: "), "GROUP, TimeVal"),
-                                tags$li(tags$strong("Chemoproteomics: "), "GROUP, DoseVal (optional DoseUnit, DrugName)")
+                                tags$li(tags$strong("Chemoproteomics: "), "GROUP, DoseVal, DoseUnit (uM, nM, mM, or M), DrugName")
                               )
                             )),
                             # Template-gated (turnover only): turnover ratios

--- a/R/module-qc-ui.R
+++ b/R/module-qc-ui.R
@@ -198,6 +198,19 @@ qcUI <- function(id) {
                h3(textOutput(ns("caption"), container = span)),
 
                tabsetPanel(id = ns("qc_tabs"),
+                 tabPanel("Data Upload",
+                          wellPanel(
+                            h4("Upload pre-processed data"),
+                            p("Bring FeatureLevelData and ProteinLevelData that were summarized in a previous session or an external pipeline. When both files are uploaded and the load page has not been used, the statistical analysis page uses them directly, skipping load-page conversion and summarization."),
+                            fileInput(ns("upload_feature_level"), "Upload FeatureLevelData (CSV)", accept = ".csv"),
+                            fileInput(ns("upload_protein_level"), "Upload ProteinLevelData (CSV)", accept = ".csv"),
+                            p(tags$strong("Required columns (names must match exactly, case-sensitive):")),
+                            tags$ul(
+                              tags$li(tags$strong("FeatureLevelData: "), "PROTEIN, PEPTIDE, FEATURE, RUN, GROUP, LABEL, INTENSITY"),
+                              tags$li(tags$strong("ProteinLevelData: "), "Protein, GROUP, RUN, LogIntensities")
+                            )
+                          )
+                 ),
                  tabPanel("Summarized Results",
                           wellPanel(
                             fluidRow(

--- a/R/module-qc-ui.R
+++ b/R/module-qc-ui.R
@@ -198,10 +198,10 @@ qcUI <- function(id) {
                h3(textOutput(ns("caption"), container = span)),
 
                tabsetPanel(id = ns("qc_tabs"),
-                 tabPanel("Summarized Analyte Abundance", value = "Data Upload",
+                 tabPanel("Upload Summarized Abundances", value = "Data Upload",
                           wellPanel(
-                            h4("Upload summarized analyte abundance"),
-                            p("Bring FeatureLevelData and ProteinLevelData that were summarized in a previous session or an external pipeline. When the required files are uploaded and the Data Upload Page has not been used, the Statistical Inference Page uses them directly, skipping conversion and summarization on the Data Upload Page."),
+                            h4("Upload summarized abundances"),
+                            p("Bring FeatureLevelData and ProteinLevelData that were summarized in a previous session or an external pipeline. When the required files are uploaded and the Data Uploading page has not been used, the Statistical Inference Page uses them directly, skipping conversion and summarization on the Data Uploading page."),
                             fileInput(ns("upload_feature_level"), "Upload FeatureLevelData (CSV)", accept = ".csv"),
                             fileInput(ns("upload_protein_level"), "Upload ProteinLevelData (CSV)", accept = ".csv"),
                             p(tags$strong("Required columns (names must match exactly, case-sensitive):")),
@@ -209,7 +209,6 @@ qcUI <- function(id) {
                               tags$li(tags$strong("FeatureLevelData: "), "PROTEIN, PEPTIDE, FEATURE, RUN, GROUP, LABEL, INTENSITY"),
                               tags$li(tags$strong("ProteinLevelData: "), "Protein, GROUP, RUN, LogIntensities (add LABEL for protein turnover)")
                             ),
-                            p(tags$em("For protein turnover, FeatureLevelData is optional; upload ProteinLevelData (with LABEL), the turnover ratios, and the GROUP mapping. Other templates require both FeatureLevelData and ProteinLevelData.")),
                             # Template-gated (turnover + chemo): GROUP mapping, shown/hidden server-side
                             shinyjs::hidden(div(
                               id = ns(NAMESPACE_QC$data_upload_mapping_panel),
@@ -217,7 +216,7 @@ qcUI <- function(id) {
                               h4("Condition mapping (CSV)",
                                  class = "icon-wrapper",
                                  icon("question-circle", lib = "font-awesome"),
-                                 div("Maps each experimental group to its numeric time point (protein turnover) or dose (chemoproteomics). This supplies the condition metadata the Data Upload Page normally collects when you convert data there. The GROUP values in this file must exactly match the GROUP values in your uploaded ProteinLevelData.",
+                                 div("Maps each experimental group to its numeric time point (protein turnover) or dose (chemoproteomics). This supplies the condition metadata the Data Uploading page normally collects when you convert data there. The GROUP values in this file must exactly match the GROUP values in your uploaded ProteinLevelData.",
                                      class = "icon-tooltip")),
                               fileInput(ns("upload_condition_mapping"), "Upload GROUP mapping (CSV)", accept = ".csv"),
                               p(tags$strong("Required columns:")),
@@ -231,8 +230,7 @@ qcUI <- function(id) {
                               id = ns(NAMESPACE_QC$data_upload_ratios_panel),
                               tags$hr(),
                               fileInput(ns("upload_turnover_ratios"), "Upload Turnover Ratios (CSV)", accept = ".csv"),
-                              p(tags$strong("Required columns: "), "Protein, TimeVal, H_frac, L_frac"),
-                              p(tags$em("FeatureLevelData is not required for turnover analysis."))
+                              p(tags$strong("Required columns: "), "Protein, TimeVal, H_frac, L_frac")
                             ))
                           )
                  ),

--- a/R/module-qc-ui.R
+++ b/R/module-qc-ui.R
@@ -208,7 +208,31 @@ qcUI <- function(id) {
                             tags$ul(
                               tags$li(tags$strong("FeatureLevelData: "), "PROTEIN, PEPTIDE, FEATURE, RUN, GROUP, LABEL, INTENSITY"),
                               tags$li(tags$strong("ProteinLevelData: "), "Protein, GROUP, RUN, LogIntensities")
-                            )
+                            ),
+                            # Template-gated (turnover + chemo): GROUP mapping, shown/hidden server-side
+                            shinyjs::hidden(div(
+                              id = ns(NAMESPACE_QC$data_upload_mapping_panel),
+                              tags$hr(),
+                              h4("Condition mapping (CSV)",
+                                 class = "icon-wrapper",
+                                 icon("question-circle", lib = "font-awesome"),
+                                 div("Maps each experimental group to its numeric time point (protein turnover) or dose (chemoproteomics). This supplies the condition metadata the load page normally collects when you convert data there. The GROUP values in this file must exactly match the GROUP values in your uploaded ProteinLevelData.",
+                                     class = "icon-tooltip")),
+                              fileInput(ns("upload_condition_mapping"), "Upload GROUP mapping (CSV)", accept = ".csv"),
+                              p(tags$strong("Required columns:")),
+                              tags$ul(
+                                tags$li(tags$strong("Protein turnover: "), "GROUP, TimeVal"),
+                                tags$li(tags$strong("Chemoproteomics: "), "GROUP, DoseVal (optional DoseUnit, DrugName)")
+                              )
+                            )),
+                            # Template-gated (turnover only): turnover ratios
+                            shinyjs::hidden(div(
+                              id = ns(NAMESPACE_QC$data_upload_ratios_panel),
+                              tags$hr(),
+                              fileInput(ns("upload_turnover_ratios"), "Upload Turnover Ratios (CSV)", accept = ".csv"),
+                              p(tags$strong("Required columns: "), "Protein, TimeVal, H_frac, L_frac"),
+                              p(tags$em("FeatureLevelData is not required for turnover analysis."))
+                            ))
                           )
                  ),
                  tabPanel("Summarized Results",

--- a/R/module-qc-ui.R
+++ b/R/module-qc-ui.R
@@ -198,10 +198,10 @@ qcUI <- function(id) {
                h3(textOutput(ns("caption"), container = span)),
 
                tabsetPanel(id = ns("qc_tabs"),
-                 tabPanel("Data Upload",
+                 tabPanel("Summarized Analyte Abundance", value = "Data Upload",
                           wellPanel(
-                            h4("Upload pre-processed data"),
-                            p("Bring FeatureLevelData and ProteinLevelData that were summarized in a previous session or an external pipeline. When the required files are uploaded and the load page has not been used, the statistical analysis page uses them directly, skipping load-page conversion and summarization."),
+                            h4("Upload summarized analyte abundance"),
+                            p("Bring FeatureLevelData and ProteinLevelData that were summarized in a previous session or an external pipeline. When the required files are uploaded and the Data Upload Page has not been used, the Statistical Inference Page uses them directly, skipping conversion and summarization on the Data Upload Page."),
                             fileInput(ns("upload_feature_level"), "Upload FeatureLevelData (CSV)", accept = ".csv"),
                             fileInput(ns("upload_protein_level"), "Upload ProteinLevelData (CSV)", accept = ".csv"),
                             p(tags$strong("Required columns (names must match exactly, case-sensitive):")),
@@ -217,7 +217,7 @@ qcUI <- function(id) {
                               h4("Condition mapping (CSV)",
                                  class = "icon-wrapper",
                                  icon("question-circle", lib = "font-awesome"),
-                                 div("Maps each experimental group to its numeric time point (protein turnover) or dose (chemoproteomics). This supplies the condition metadata the load page normally collects when you convert data there. The GROUP values in this file must exactly match the GROUP values in your uploaded ProteinLevelData.",
+                                 div("Maps each experimental group to its numeric time point (protein turnover) or dose (chemoproteomics). This supplies the condition metadata the Data Upload Page normally collects when you convert data there. The GROUP values in this file must exactly match the GROUP values in your uploaded ProteinLevelData.",
                                      class = "icon-tooltip")),
                               fileInput(ns("upload_condition_mapping"), "Upload GROUP mapping (CSV)", accept = ".csv"),
                               p(tags$strong("Required columns:")),

--- a/R/module-statmodel-server.R
+++ b/R/module-statmodel-server.R
@@ -170,7 +170,7 @@ statmodelServer = function(id, parent_session, loadpage_input, qc_input,
                                         stringsAsFactors = FALSE)
               } else {
                 showNotification(
-                  "Please enter time values for each condition on the data upload page.",
+                  "Please enter time values for each condition on the Data Uploading page.",
                   type = "warning", duration = 8
                 )
                 disable(NAMESPACE_STATMODEL$modeling_start)
@@ -188,7 +188,7 @@ statmodelServer = function(id, parent_session, loadpage_input, qc_input,
                 )
               } else {
                 showNotification(
-                  "Please enter dose values for each condition on the data upload page.",
+                  "Please enter dose values for each condition on the Data Uploading page.",
                   type = "warning", duration = 8
                 )
                 disable(NAMESPACE_STATMODEL$modeling_start)
@@ -351,7 +351,7 @@ statmodelServer = function(id, parent_session, loadpage_input, qc_input,
               check_cols <- intersect(c("DoseVal", "TimeVal", "DoseUnit"), colnames(meta))
               if (any(sapply(check_cols, function(col) "?" %in% meta[[col]]))) {
                 showNotification(
-                  "Please fill in all '?' values in the condition metadata table on the data upload page before running the analysis.",
+                  "Please fill in all '?' values in the condition metadata table on the Data Uploading page before running the analysis.",
                   type = "error", duration = 8
                 )
                 req(FALSE)

--- a/R/module-statmodel-server.R
+++ b/R/module-statmodel-server.R
@@ -89,7 +89,7 @@ statmodelServer = function(id, parent_session, loadpage_input, qc_input,
 
       # UI visibility
       observe({
-        if (isTRUE(loadpage_input()$DDA_DIA == "TMT") | isTRUE(loadpage_input()$BIO == "PTM")) {
+        if (isTRUE(loadpage_input()$DDA_DIA == "TMT") || isTRUE(loadpage_input()$BIO == "PTM")) {
           hide("Design")
         } else {
           shinyjs::show("Design")

--- a/R/module-statmodel-server.R
+++ b/R/module-statmodel-server.R
@@ -111,7 +111,7 @@ statmodelServer = function(id, parent_session, loadpage_input, qc_input,
         tryCatch({ rownames(matrix_build()) }, error = function(e) {})
       })
       
-      render_group_comparison_plot_inputs(output, session, Rownames, get_data, input, loadpage_input, condition_list, contrast, app_template, condition_metadata)
+      render_group_comparison_plot_inputs(output, session, Rownames, get_data, input, loadpage_input, condition_list, contrast, app_template, condition_metadata, preprocess_data)
 
       output[[NAMESPACE_STATMODEL$comparisons_exclude_conditions]] <- renderUI({
         req(input[[NAMESPACE_STATMODEL$comparison_mode]] ==

--- a/R/module-statmodel-server.R
+++ b/R/module-statmodel-server.R
@@ -89,7 +89,7 @@ statmodelServer = function(id, parent_session, loadpage_input, qc_input,
 
       # UI visibility
       observe({
-        if (loadpage_input()$DDA_DIA == "TMT" | loadpage_input()$BIO == "PTM") {
+        if (isTRUE(loadpage_input()$DDA_DIA == "TMT") | isTRUE(loadpage_input()$BIO == "PTM")) {
           hide("Design")
         } else {
           shinyjs::show("Design")

--- a/R/qc-server-data-upload.R
+++ b/R/qc-server-data-upload.R
@@ -41,16 +41,63 @@ qc_missing_upload_columns <- function(present_cols, required_cols) {
 #' Whether the uploaded set is complete enough to bypass QC summarization.
 #'
 #' Default and chemoproteomics templates require both FeatureLevelData and
-#' ProteinLevelData. The protein-turnover branch is a stub for commit 2, which
-#' will fold in the uploaded ratios / metadata; for now it mirrors the two-file
-#' rule.
+#' ProteinLevelData. Protein turnover requires ProteinLevelData plus the uploaded
+#' turnover-ratios table; FeatureLevelData is not used on the turnover
+#' response-curve path (the fit consumes the ratios table directly).
 #' @noRd
 qc_uploads_complete <- function(template, has_feature, has_protein, has_turnover) {
   if (!is.null(template) && template == TEMPLATES$protein_turnover) {
-    has_feature && has_protein
+    has_protein && has_turnover
   } else {
     has_feature && has_protein
   }
+}
+
+#' Required GROUP mapping columns for the uploaded condition-metadata CSV.
+#'
+#' Protein turnover needs GROUP + TimeVal; chemoproteomics needs GROUP + DoseVal
+#' (DoseUnit / DrugName are optional and defaulted downstream).
+#' @noRd
+qc_required_mapping_columns <- function(template) {
+  if (!is.null(template) && template == TEMPLATES$protein_turnover) {
+    c("GROUP", "TimeVal")
+  } else if (!is.null(template) && template == TEMPLATES$chemoproteomics) {
+    c("GROUP", "DoseVal")
+  } else {
+    character(0)
+  }
+}
+
+#' Required columns for an uploaded turnover-ratios CSV.
+#'
+#' Matches what prepare_turnover_for_dose_response reads from the
+#' MSstatsResponse::calculateTurnoverRatios output (BaseSequence is optional).
+#' @noRd
+qc_required_ratios_columns <- function() {
+  c("Protein", "TimeVal", "H_frac", "L_frac")
+}
+
+#' Translate an uploaded GROUP mapping CSV into the condition_metadata format.
+#'
+#' The load page stores condition_metadata with a Condition column; the uploaded
+#' CSV uses GROUP (identical values, user-facing name). Renames GROUP to
+#' Condition and keeps the template-specific value columns, all coerced to
+#' character to match the load-page format.
+#' @noRd
+qc_mapping_to_condition_metadata <- function(parsed, template) {
+  df = data.frame(Condition = as.character(parsed$GROUP), stringsAsFactors = FALSE)
+  if (!is.null(template) && template == TEMPLATES$protein_turnover) {
+    df$TimeVal = as.character(parsed$TimeVal)
+  } else if (!is.null(template) && template == TEMPLATES$chemoproteomics) {
+    df$DoseVal = as.character(parsed$DoseVal)
+    if ("DoseUnit" %in% colnames(parsed)) {
+      df$DoseUnit = as.character(parsed$DoseUnit)
+    }
+    if ("DrugName" %in% colnames(parsed)) {
+      df$DrugName = as.character(parsed$DrugName)
+    }
+  }
+  df
 }
 
 # ----------------------------------------------------------------------------
@@ -61,10 +108,12 @@ qc_uploads_complete <- function(template, has_feature, has_protein, has_turnover
 #' visibility, and the effective preprocess reactive returned to stat-analysis.
 #' @noRd
 register_qc_data_upload <- function(input, output, session, loadpage_input,
-                                    app_template, get_data, preprocess_data) {
+                                    app_template, get_data, preprocess_data,
+                                    get_condition_metadata, turnover_ratios) {
 
   uploaded_feature_level = reactiveVal(NULL)
   uploaded_protein_level = reactiveVal(NULL)
+  uploaded_turnover_ratios = reactiveVal(NULL)
 
   get_template = function() if (!is.null(app_template)) app_template() else NULL
 
@@ -72,7 +121,7 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
     qc_uploads_complete(get_template(),
                         !is.null(uploaded_feature_level()),
                         !is.null(uploaded_protein_level()),
-                        has_turnover = FALSE)
+                        has_turnover = !is.null(uploaded_turnover_ratios()))
   })
 
   # ---- Parse + validate uploaded CSVs ----
@@ -106,6 +155,7 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
       return()
     }
     parsed$GROUP = factor(parsed$GROUP)
+    parsed = as.data.frame(parsed)
     uploaded_feature_level(parsed)
     if (is.null(uploaded_protein_level())) {
       showNotification("FeatureLevelData uploaded. Please also upload ProteinLevelData.",
@@ -139,9 +189,115 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
       return()
     }
     parsed$GROUP = factor(parsed$GROUP)
+    parsed = as.data.frame(parsed)
     uploaded_protein_level(parsed)
-    if (is.null(uploaded_feature_level())) {
+    if (!is.null(get_template()) && get_template() == TEMPLATES$protein_turnover) {
+      showNotification(paste("ProteinLevelData uploaded. Please also upload the turnover ratios",
+                             "and the GROUP to TimeVal mapping."),
+                       type = "message", duration = 6)
+    } else if (is.null(uploaded_feature_level())) {
       showNotification("ProteinLevelData uploaded. Please also upload FeatureLevelData.",
+                       type = "message", duration = 6)
+    }
+  })
+
+  # ---- Mapping CSV: GROUP -> time/dose, written into condition_metadata ----
+  # Turnover uses GROUP + TimeVal; chemo uses GROUP + DoseVal (+ optional
+  # DoseUnit / DrugName). GROUP is renamed to Condition so downstream turnover /
+  # chemo code consumes it unchanged.
+
+  observeEvent(input$upload_condition_mapping, {
+    file = input$upload_condition_mapping
+    req(file)
+    template = get_template()
+    parsed = tryCatch(
+      data.table::fread(file$datapath),
+      error = function(e) {
+        showNotification(paste("Could not read GROUP mapping:", conditionMessage(e)),
+                         type = "error", duration = 10)
+        NULL
+      }
+    )
+    if (is.null(parsed)) return()
+
+    missing = qc_missing_upload_columns(colnames(parsed),
+                                        qc_required_mapping_columns(template))
+    if (length(missing) > 0) {
+      showNotification(
+        paste0("GROUP mapping is missing required column(s): ",
+               paste(missing, collapse = ", ")),
+        type = "error", duration = 10)
+      return()
+    }
+
+    # Value column must be numeric-coercible: blank / non-numeric entries become
+    # NA downstream and fail the fit silently.
+    value_col = if (!is.null(template) && template == TEMPLATES$protein_turnover) "TimeVal" else "DoseVal"
+    if (any(is.na(suppressWarnings(as.numeric(parsed[[value_col]]))))) {
+      showNotification(
+        paste0("GROUP mapping ", value_col,
+               " must be numeric for every row (found blank or non-numeric values)."),
+        type = "error", duration = 10)
+      return()
+    }
+
+    # GROUP values must match the uploaded ProteinLevelData: the chemo fit merges
+    # by GROUP and silently drops non-matching rows.
+    pld = uploaded_protein_level()
+    if (is.null(pld)) {
+      showNotification("Please upload ProteinLevelData before the GROUP mapping.",
+                       type = "error", duration = 10)
+      return()
+    }
+    protein_groups = levels(pld$GROUP)
+    if (is.null(protein_groups)) {
+      protein_groups = unique(as.character(pld$GROUP))
+    }
+    unmatched = setdiff(as.character(parsed$GROUP), protein_groups)
+    if (length(unmatched) > 0) {
+      showNotification(
+        paste0("GROUP mapping has GROUP value(s) not found in ProteinLevelData: ",
+               paste(unmatched, collapse = ", ")),
+        type = "error", duration = 10)
+      return()
+    }
+
+    if (!is.null(get_condition_metadata)) {
+      get_condition_metadata(qc_mapping_to_condition_metadata(parsed, template))
+    }
+    showNotification("GROUP mapping uploaded.", type = "message", duration = 6)
+  })
+
+  # ---- Turnover-ratios CSV (protein-turnover template) ----
+
+  observeEvent(input$upload_turnover_ratios, {
+    file = input$upload_turnover_ratios
+    req(file)
+    parsed = tryCatch(
+      data.table::fread(file$datapath),
+      error = function(e) {
+        showNotification(paste("Could not read Turnover Ratios:", conditionMessage(e)),
+                         type = "error", duration = 10)
+        NULL
+      }
+    )
+    if (is.null(parsed)) {
+      uploaded_turnover_ratios(NULL)
+      return()
+    }
+    missing = qc_missing_upload_columns(colnames(parsed), qc_required_ratios_columns())
+    if (length(missing) > 0) {
+      showNotification(
+        paste0("Turnover Ratios is missing required column(s): ",
+               paste(missing, collapse = ", ")),
+        type = "error", duration = 10)
+      uploaded_turnover_ratios(NULL)
+      return()
+    }
+    uploaded_turnover_ratios(as.data.frame(parsed))
+    if (is.null(uploaded_protein_level())) {
+      showNotification(paste("Turnover Ratios uploaded. Please also upload ProteinLevelData",
+                             "and the GROUP to TimeVal mapping."),
                        type = "message", duration = 6)
     }
   })
@@ -157,6 +313,19 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
            ProteinLevelData = uploaded_protein_level())
     } else {
       preprocess_data()
+    }
+  })
+
+  # ---- Effective turnover ratios: uploaded table when the load page was unused ----
+  # turnover_ratios (commit 1) is an eventReactive on input$run, which never fires
+  # on the upload path, so return the uploaded ratios directly when present.
+
+  effective_turnover_ratios = reactive({
+    loaded = tryCatch(get_data(), error = function(e) NULL)
+    if (is.null(loaded) && !is.null(uploaded_turnover_ratios())) {
+      uploaded_turnover_ratios()
+    } else {
+      turnover_ratios()
     }
   })
 
@@ -180,8 +349,23 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
                                   is.null(uploaded_protein_level()))
   })
 
+  # ---- Template-gated upload panels: mapping (turnover + chemo), ratios (turnover) ----
+
+  observeEvent(get_template(), {
+    t = get_template()
+    shinyjs::toggle(
+      NAMESPACE_QC$data_upload_mapping_panel,
+      condition = !is.null(t) && t %in% c(TEMPLATES$protein_turnover, TEMPLATES$chemoproteomics)
+    )
+    shinyjs::toggle(
+      NAMESPACE_QC$data_upload_ratios_panel,
+      condition = !is.null(t) && t == TEMPLATES$protein_turnover
+    )
+  }, ignoreNULL = FALSE)
+
   list(
     effective_preprocess_data = effective_preprocess_data,
+    effective_turnover_ratios = effective_turnover_ratios,
     uploaded_feature_level = uploaded_feature_level,
     uploaded_protein_level = uploaded_protein_level
   )

--- a/R/qc-server-data-upload.R
+++ b/R/qc-server-data-upload.R
@@ -1,0 +1,188 @@
+# QC Data Upload tab: parse and validate user-supplied FeatureLevelData /
+# ProteinLevelData CSVs, show the tab only until load-page data exists, and swap
+# the uploaded tables into an effective preprocess reactive that the
+# stat-analysis page consumes in place of QC summarization output.
+
+# ----------------------------------------------------------------------------
+# Pure column / completeness helpers. Functions of plain vectors and booleans so
+# they can be unit-tested directly without a Shiny session.
+# ----------------------------------------------------------------------------
+
+#' Required ProteinLevelData columns for an uploaded summarization table.
+#'
+#' Confirmed against MSstats::MSstatsSummarizationOutput. LABEL (heavy/light
+#' channel) is only required for the protein-turnover template; commit 2 uses it.
+#' @noRd
+qc_required_protein_columns <- function(template) {
+  cols = c("Protein", "GROUP", "RUN", "LogIntensities")
+  if (!is.null(template) && template == TEMPLATES$protein_turnover) {
+    cols = c(cols, "LABEL")
+  }
+  cols
+}
+
+#' Required FeatureLevelData columns for an uploaded summarization table.
+#'
+#' Confirmed against MSstats::MSstatsSummarizationOutput (PROTEIN and INTENSITY
+#' are upper-case; TRANSITION is intentionally omitted because it can be a
+#' placeholder for non-fragment workflows). Template-independent for now; the
+#' argument is kept for symmetry with qc_required_protein_columns.
+#' @noRd
+qc_required_feature_columns <- function(template) {
+  c("PROTEIN", "PEPTIDE", "FEATURE", "RUN", "GROUP", "LABEL", "INTENSITY")
+}
+
+#' Columns in `required_cols` that are absent from `present_cols`.
+#' @noRd
+qc_missing_upload_columns <- function(present_cols, required_cols) {
+  setdiff(required_cols, present_cols)
+}
+
+#' Whether the uploaded set is complete enough to bypass QC summarization.
+#'
+#' Default and chemoproteomics templates require both FeatureLevelData and
+#' ProteinLevelData. The protein-turnover branch is a stub for commit 2, which
+#' will fold in the uploaded ratios / metadata; for now it mirrors the two-file
+#' rule.
+#' @noRd
+qc_uploads_complete <- function(template, has_feature, has_protein, has_turnover) {
+  if (!is.null(template) && template == TEMPLATES$protein_turnover) {
+    has_feature && has_protein
+  } else {
+    has_feature && has_protein
+  }
+}
+
+# ----------------------------------------------------------------------------
+# Server registration.
+# ----------------------------------------------------------------------------
+
+#' Register the QC Data Upload tab: CSV parsing, column validation, tab
+#' visibility, and the effective preprocess reactive returned to stat-analysis.
+#' @noRd
+register_qc_data_upload <- function(input, output, session, loadpage_input,
+                                    app_template, get_data, preprocess_data) {
+
+  uploaded_feature_level = reactiveVal(NULL)
+  uploaded_protein_level = reactiveVal(NULL)
+
+  get_template = function() if (!is.null(app_template)) app_template() else NULL
+
+  uploads_complete = reactive({
+    qc_uploads_complete(get_template(),
+                        !is.null(uploaded_feature_level()),
+                        !is.null(uploaded_protein_level()),
+                        has_turnover = FALSE)
+  })
+
+  # ---- Parse + validate uploaded CSVs ----
+  # fread returns a data.table by default (feedback_fread_default_type); columns
+  # are validated by name, not position. GROUP is coerced to a factor so
+  # stat-analysis can derive the condition list from levels(GROUP).
+
+  observeEvent(input$upload_feature_level, {
+    file = input$upload_feature_level
+    req(file)
+    parsed = tryCatch(
+      data.table::fread(file$datapath),
+      error = function(e) {
+        showNotification(paste("Could not read FeatureLevelData:", conditionMessage(e)),
+                         type = "error", duration = 10)
+        NULL
+      }
+    )
+    if (is.null(parsed)) {
+      uploaded_feature_level(NULL)
+      return()
+    }
+    missing = qc_missing_upload_columns(colnames(parsed),
+                                        qc_required_feature_columns(get_template()))
+    if (length(missing) > 0) {
+      showNotification(
+        paste0("FeatureLevelData is missing required column(s): ",
+               paste(missing, collapse = ", ")),
+        type = "error", duration = 10)
+      uploaded_feature_level(NULL)
+      return()
+    }
+    parsed$GROUP = factor(parsed$GROUP)
+    uploaded_feature_level(parsed)
+    if (is.null(uploaded_protein_level())) {
+      showNotification("FeatureLevelData uploaded. Please also upload ProteinLevelData.",
+                       type = "message", duration = 6)
+    }
+  })
+
+  observeEvent(input$upload_protein_level, {
+    file = input$upload_protein_level
+    req(file)
+    parsed = tryCatch(
+      data.table::fread(file$datapath),
+      error = function(e) {
+        showNotification(paste("Could not read ProteinLevelData:", conditionMessage(e)),
+                         type = "error", duration = 10)
+        NULL
+      }
+    )
+    if (is.null(parsed)) {
+      uploaded_protein_level(NULL)
+      return()
+    }
+    missing = qc_missing_upload_columns(colnames(parsed),
+                                        qc_required_protein_columns(get_template()))
+    if (length(missing) > 0) {
+      showNotification(
+        paste0("ProteinLevelData is missing required column(s): ",
+               paste(missing, collapse = ", ")),
+        type = "error", duration = 10)
+      uploaded_protein_level(NULL)
+      return()
+    }
+    parsed$GROUP = factor(parsed$GROUP)
+    uploaded_protein_level(parsed)
+    if (is.null(uploaded_feature_level())) {
+      showNotification("ProteinLevelData uploaded. Please also upload FeatureLevelData.",
+                       type = "message", duration = 6)
+    }
+  })
+
+  # ---- Effective preprocess: uploaded tables when the load page was not used ----
+  # Falls back to the raw preprocess_data() eventReactive whenever load-page data
+  # exists or the uploads are incomplete, so existing flows are unchanged.
+
+  effective_preprocess_data = reactive({
+    loaded = tryCatch(get_data(), error = function(e) NULL)
+    if (is.null(loaded) && uploads_complete()) {
+      list(FeatureLevelData = uploaded_feature_level(),
+           ProteinLevelData = uploaded_protein_level())
+    } else {
+      preprocess_data()
+    }
+  })
+
+  # ---- Tab visibility: show only until load-page data exists ----
+  # Move a user off the tab before hiding it so they are not stranded on a
+  # hidden pane.
+
+  observeEvent(get_data(), {
+    if (is.null(get_data())) {
+      showTab(inputId = "qc_tabs", target = "Data Upload", session = session)
+    } else {
+      updateTabsetPanel(session = session, inputId = "qc_tabs", selected = "Summarized Results")
+      hideTab(inputId = "qc_tabs", target = "Data Upload", session = session)
+    }
+  }, ignoreNULL = FALSE)
+
+  # ---- Disable the summarization Run button while uploads are in play ----
+
+  observe({
+    shinyjs::toggleState("run", is.null(uploaded_feature_level()) &&
+                                  is.null(uploaded_protein_level()))
+  })
+
+  list(
+    effective_preprocess_data = effective_preprocess_data,
+    uploaded_feature_level = uploaded_feature_level,
+    uploaded_protein_level = uploaded_protein_level
+  )
+}

--- a/R/qc-server-data-upload.R
+++ b/R/qc-server-data-upload.R
@@ -333,8 +333,9 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
   # Move a user off the tab before hiding it so they are not stranded on a
   # hidden pane.
 
-  observeEvent(get_data(), {
-    if (is.null(get_data())) {
+  observeEvent(tryCatch(get_data(), error = function(e) NULL), {
+    loaded = tryCatch(get_data(), error = function(e) NULL)
+    if (is.null(loaded)) {
       showTab(inputId = "qc_tabs", target = "Data Upload", session = session)
     } else {
       updateTabsetPanel(session = session, inputId = "qc_tabs", selected = "Summarized Results")

--- a/R/qc-server-data-upload.R
+++ b/R/qc-server-data-upload.R
@@ -11,7 +11,7 @@
 #' Required ProteinLevelData columns for an uploaded summarization table.
 #'
 #' Confirmed against MSstats::MSstatsSummarizationOutput. LABEL (heavy/light
-#' channel) is only required for the protein-turnover template; commit 2 uses it.
+#' channel) is only required for the protein-turnover template.
 #' @noRd
 qc_required_protein_columns <- function(template) {
   cols = c("Protein", "GROUP", "RUN", "LogIntensities")
@@ -40,14 +40,18 @@ qc_missing_upload_columns <- function(present_cols, required_cols) {
 
 #' Whether the uploaded set is complete enough to bypass QC summarization.
 #'
-#' Default and chemoproteomics templates require both FeatureLevelData and
-#' ProteinLevelData. Protein turnover requires ProteinLevelData plus the uploaded
-#' turnover-ratios table; FeatureLevelData is not used on the turnover
-#' response-curve path (the fit consumes the ratios table directly).
+#' Default templates require FeatureLevelData and ProteinLevelData. Chemoproteomics
+#' additionally requires a valid GROUP mapping. Protein turnover requires
+#' ProteinLevelData, the turnover-ratios table, and a valid GROUP mapping;
+#' FeatureLevelData is not used on the turnover response-curve path (the fit
+#' consumes the ratios table directly).
 #' @noRd
-qc_uploads_complete <- function(template, has_feature, has_protein, has_turnover) {
+qc_uploads_complete <- function(template, has_feature, has_protein, has_turnover,
+                                has_mapping) {
   if (!is.null(template) && template == TEMPLATES$protein_turnover) {
-    has_protein && has_turnover
+    has_protein && has_turnover && has_mapping
+  } else if (!is.null(template) && template == TEMPLATES$chemoproteomics) {
+    has_feature && has_protein && has_mapping
   } else {
     has_feature && has_protein
   }
@@ -55,14 +59,15 @@ qc_uploads_complete <- function(template, has_feature, has_protein, has_turnover
 
 #' Required GROUP mapping columns for the uploaded condition-metadata CSV.
 #'
-#' Protein turnover needs GROUP + TimeVal; chemoproteomics needs GROUP + DoseVal
-#' (DoseUnit / DrugName are optional and defaulted downstream).
+#' Protein turnover needs GROUP + TimeVal; chemoproteomics needs GROUP, DoseVal,
+#' DoseUnit, and DrugName (DoseUnit feeds the dose-to-molar conversion, so it is
+#' required rather than defaulted).
 #' @noRd
 qc_required_mapping_columns <- function(template) {
   if (!is.null(template) && template == TEMPLATES$protein_turnover) {
     c("GROUP", "TimeVal")
   } else if (!is.null(template) && template == TEMPLATES$chemoproteomics) {
-    c("GROUP", "DoseVal")
+    c("GROUP", "DoseVal", "DoseUnit", "DrugName")
   } else {
     character(0)
   }
@@ -100,6 +105,61 @@ qc_mapping_to_condition_metadata <- function(parsed, template) {
   df
 }
 
+#' Whether every dose unit is one convert_dose_to_molar recognizes.
+#'
+#' convert_dose_to_molar silently treats an unrecognized unit as molar
+#' (multiplier 1), so units are validated up front. Accepts nM, uM, mM, M
+#' (case-insensitive, surrounding whitespace ignored).
+#' @noRd
+qc_dose_units_valid <- function(units) {
+  if (is.null(units) || length(units) == 0) return(FALSE)
+  normalized = tolower(trimws(as.character(units)))
+  all(!is.na(normalized) & normalized %in% c("nm", "um", "mm", "m"))
+}
+
+#' Errors for a GROUP mapping that must have one row per ProteinLevelData GROUP.
+#'
+#' Returns a character vector of messages (empty when valid): unknown mapping
+#' groups, ProteinLevelData groups missing from the mapping, and duplicated
+#' mapping rows. Missing or duplicated groups otherwise corrupt the GROUP join.
+#' @noRd
+qc_mapping_group_errors <- function(mapping_groups, protein_groups) {
+  mapping_groups = as.character(mapping_groups)
+  protein_groups = as.character(protein_groups)
+  errors = character(0)
+  unknown = setdiff(mapping_groups, protein_groups)
+  if (length(unknown) > 0) {
+    errors = c(errors, paste0("GROUP mapping has GROUP value(s) not found in ProteinLevelData: ",
+                              paste(unknown, collapse = ", "), "."))
+  }
+  missing_groups = setdiff(protein_groups, mapping_groups)
+  if (length(missing_groups) > 0) {
+    errors = c(errors, paste0("GROUP mapping is missing row(s) for ProteinLevelData GROUP(s): ",
+                              paste(missing_groups, collapse = ", "), "."))
+  }
+  duplicated_groups = unique(mapping_groups[duplicated(mapping_groups)])
+  if (length(duplicated_groups) > 0) {
+    errors = c(errors, paste0("GROUP mapping has duplicate row(s) for GROUP(s): ",
+                              paste(duplicated_groups, collapse = ", "), "."))
+  }
+  errors
+}
+
+#' Whether every value in the named columns is numeric-coercible and finite.
+#'
+#' Returns FALSE if any column is absent or holds a blank / non-numeric /
+#' non-finite value. Rejects turnover-ratios uploads that would fail the fit
+#' silently.
+#' @noRd
+qc_values_numeric_finite <- function(df, cols) {
+  if (!all(cols %in% colnames(df))) return(FALSE)
+  for (col in cols) {
+    vals = suppressWarnings(as.numeric(df[[col]]))
+    if (any(!is.finite(vals))) return(FALSE)
+  }
+  TRUE
+}
+
 # ----------------------------------------------------------------------------
 # Server registration.
 # ----------------------------------------------------------------------------
@@ -114,6 +174,9 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
   uploaded_feature_level = reactiveVal(NULL)
   uploaded_protein_level = reactiveVal(NULL)
   uploaded_turnover_ratios = reactiveVal(NULL)
+  # TRUE only after an uploaded GROUP mapping passes every validation check;
+  # required before turnover / chemo uploads are considered ready.
+  mapping_valid = reactiveVal(FALSE)
 
   get_template = function() if (!is.null(app_template)) app_template() else NULL
 
@@ -121,7 +184,8 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
     qc_uploads_complete(get_template(),
                         !is.null(uploaded_feature_level()),
                         !is.null(uploaded_protein_level()),
-                        has_turnover = !is.null(uploaded_turnover_ratios()))
+                        has_turnover = !is.null(uploaded_turnover_ratios()),
+                        has_mapping = isTRUE(mapping_valid()))
   })
 
   # ---- Parse + validate uploaded CSVs ----
@@ -202,14 +266,16 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
   })
 
   # ---- Mapping CSV: GROUP -> time/dose, written into condition_metadata ----
-  # Turnover uses GROUP + TimeVal; chemo uses GROUP + DoseVal (+ optional
-  # DoseUnit / DrugName). GROUP is renamed to Condition so downstream turnover /
-  # chemo code consumes it unchanged.
+  # Turnover uses GROUP + TimeVal; chemo uses GROUP + DoseVal + DoseUnit +
+  # DrugName. GROUP is renamed to Condition so downstream turnover / chemo code
+  # consumes it unchanged.
 
   observeEvent(input$upload_condition_mapping, {
     file = input$upload_condition_mapping
     req(file)
     template = get_template()
+    # Clear validity on every (re-)upload; only a fully validated mapping sets it.
+    mapping_valid(FALSE)
     parsed = tryCatch(
       data.table::fread(file$datapath),
       error = function(e) {
@@ -241,8 +307,18 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
       return()
     }
 
-    # GROUP values must match the uploaded ProteinLevelData: the chemo fit merges
-    # by GROUP and silently drops non-matching rows.
+    # Chemo dose units feed convert_dose_to_molar, which silently treats an
+    # unrecognized unit as molar; reject unknown units up front.
+    if (!is.null(template) && template == TEMPLATES$chemoproteomics &&
+        !qc_dose_units_valid(parsed$DoseUnit)) {
+      showNotification(
+        "GROUP mapping DoseUnit must be one of nM, uM, mM, or M for every row.",
+        type = "error", duration = 10)
+      return()
+    }
+
+    # GROUP values must line up one-to-one with the uploaded ProteinLevelData;
+    # unknown groups, missing groups, or duplicate rows all corrupt the join.
     pld = uploaded_protein_level()
     if (is.null(pld)) {
       showNotification("Please upload ProteinLevelData before the GROUP mapping.",
@@ -253,18 +329,17 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
     if (is.null(protein_groups)) {
       protein_groups = unique(as.character(pld$GROUP))
     }
-    unmatched = setdiff(as.character(parsed$GROUP), protein_groups)
-    if (length(unmatched) > 0) {
-      showNotification(
-        paste0("GROUP mapping has GROUP value(s) not found in ProteinLevelData: ",
-               paste(unmatched, collapse = ", ")),
-        type = "error", duration = 10)
+    group_errors = qc_mapping_group_errors(parsed$GROUP, protein_groups)
+    if (length(group_errors) > 0) {
+      showNotification(paste(group_errors, collapse = " "),
+                       type = "error", duration = 10)
       return()
     }
 
     if (!is.null(get_condition_metadata)) {
       get_condition_metadata(qc_mapping_to_condition_metadata(parsed, template))
     }
+    mapping_valid(TRUE)
     showNotification("GROUP mapping uploaded.", type = "message", duration = 6)
   })
 
@@ -294,6 +369,13 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
       uploaded_turnover_ratios(NULL)
       return()
     }
+    if (!qc_values_numeric_finite(parsed, c("TimeVal", "H_frac", "L_frac"))) {
+      showNotification(
+        "Turnover Ratios TimeVal, H_frac, and L_frac must be numeric and finite for every row.",
+        type = "error", duration = 10)
+      uploaded_turnover_ratios(NULL)
+      return()
+    }
     uploaded_turnover_ratios(as.data.frame(parsed))
     if (is.null(uploaded_protein_level())) {
       showNotification(paste("Turnover Ratios uploaded. Please also upload ProteinLevelData",
@@ -317,8 +399,8 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
   })
 
   # ---- Effective turnover ratios: uploaded table when the load page was unused ----
-  # turnover_ratios (commit 1) is an eventReactive on input$run, which never fires
-  # on the upload path, so return the uploaded ratios directly when present.
+  # turnover_ratios is an eventReactive on input$run, which never fires on the
+  # upload path, so return the uploaded ratios directly when present.
 
   effective_turnover_ratios = reactive({
     loaded = tryCatch(get_data(), error = function(e) NULL)

--- a/R/qc-server-data-upload.R
+++ b/R/qc-server-data-upload.R
@@ -4,8 +4,7 @@
 # stat-analysis page consumes in place of QC summarization output.
 
 # ----------------------------------------------------------------------------
-# Pure column / completeness helpers. Functions of plain vectors and booleans so
-# they can be unit-tested directly without a Shiny session.
+# Pure column / completeness helpers.
 # ----------------------------------------------------------------------------
 
 #' Required ProteinLevelData columns for an uploaded summarization table.
@@ -13,7 +12,7 @@
 #' Confirmed against MSstats::MSstatsSummarizationOutput. LABEL (heavy/light
 #' channel) is only required for the protein-turnover template.
 #' @noRd
-qc_required_protein_columns <- function(template) {
+get_qc_required_protein_columns <- function(template) {
   cols = c("Protein", "GROUP", "RUN", "LogIntensities")
   if (!is.null(template) && template == TEMPLATES$protein_turnover) {
     cols = c(cols, "LABEL")
@@ -25,31 +24,28 @@ qc_required_protein_columns <- function(template) {
 #'
 #' Confirmed against MSstats::MSstatsSummarizationOutput (PROTEIN and INTENSITY
 #' are upper-case; TRANSITION is intentionally omitted because it can be a
-#' placeholder for non-fragment workflows). Template-independent for now; the
-#' argument is kept for symmetry with qc_required_protein_columns.
+#' placeholder for non-fragment workflows).
 #' @noRd
-qc_required_feature_columns <- function(template) {
+get_qc_required_feature_columns <- function() {
   c("PROTEIN", "PEPTIDE", "FEATURE", "RUN", "GROUP", "LABEL", "INTENSITY")
 }
 
 #' Columns in `required_cols` that are absent from `present_cols`.
 #' @noRd
-qc_missing_upload_columns <- function(present_cols, required_cols) {
+get_missing_upload_columns <- function(present_cols, required_cols) {
   setdiff(required_cols, present_cols)
 }
 
 #' Whether the uploaded set is complete enough to bypass QC summarization.
 #'
-#' Default templates require FeatureLevelData and ProteinLevelData. Chemoproteomics
-#' additionally requires a valid GROUP mapping. Protein turnover requires
-#' ProteinLevelData, the turnover-ratios table, and a valid GROUP mapping;
-#' FeatureLevelData is not used on the turnover response-curve path (the fit
-#' consumes the ratios table directly).
+#' All templates require FeatureLevelData and ProteinLevelData. Chemoproteomics
+#' and protein turnover additionally require a valid GROUP mapping; protein
+#' turnover also requires the turnover-ratios table.
 #' @noRd
 qc_uploads_complete <- function(template, has_feature, has_protein, has_turnover,
                                 has_mapping) {
   if (!is.null(template) && template == TEMPLATES$protein_turnover) {
-    has_protein && has_turnover && has_mapping
+    has_feature && has_protein && has_turnover && has_mapping
   } else if (!is.null(template) && template == TEMPLATES$chemoproteomics) {
     has_feature && has_protein && has_mapping
   } else {
@@ -63,7 +59,7 @@ qc_uploads_complete <- function(template, has_feature, has_protein, has_turnover
 #' DoseUnit, and DrugName (DoseUnit feeds the dose-to-molar conversion, so it is
 #' required rather than defaulted).
 #' @noRd
-qc_required_mapping_columns <- function(template) {
+get_qc_required_mapping_columns <- function(template) {
   if (!is.null(template) && template == TEMPLATES$protein_turnover) {
     c("GROUP", "TimeVal")
   } else if (!is.null(template) && template == TEMPLATES$chemoproteomics) {
@@ -78,7 +74,7 @@ qc_required_mapping_columns <- function(template) {
 #' Matches what prepare_turnover_for_dose_response reads from the
 #' MSstatsResponse::calculateTurnoverRatios output (BaseSequence is optional).
 #' @noRd
-qc_required_ratios_columns <- function() {
+get_qc_required_ratios_columns <- function() {
   c("Protein", "TimeVal", "H_frac", "L_frac")
 }
 
@@ -147,15 +143,21 @@ qc_mapping_group_errors <- function(mapping_groups, protein_groups) {
 
 #' Whether every value in the named columns is numeric-coercible and finite.
 #'
-#' Returns FALSE if any column is absent or holds a blank / non-numeric /
-#' non-finite value. Rejects turnover-ratios uploads that would fail the fit
-#' silently.
+#' With allow_na = TRUE, NA or blank entries pass but any present value must
+#' still be finite numeric. Rejects turnover-ratios uploads that would fail the
+#' fit silently.
 #' @noRd
-qc_values_numeric_finite <- function(df, cols) {
+qc_values_numeric_finite <- function(df, cols, allow_na = FALSE) {
   if (!all(cols %in% colnames(df))) return(FALSE)
   for (col in cols) {
-    vals = suppressWarnings(as.numeric(df[[col]]))
-    if (any(!is.finite(vals))) return(FALSE)
+    raw = df[[col]]
+    coerced = suppressWarnings(as.numeric(raw))
+    if (allow_na) {
+      blank = is.na(raw) | trimws(as.character(raw)) == ""
+      if (any(!blank & !is.finite(coerced))) return(FALSE)
+    } else {
+      if (any(!is.finite(coerced))) return(FALSE)
+    }
   }
   TRUE
 }
@@ -174,8 +176,6 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
   uploaded_feature_level = reactiveVal(NULL)
   uploaded_protein_level = reactiveVal(NULL)
   uploaded_turnover_ratios = reactiveVal(NULL)
-  # TRUE only after an uploaded GROUP mapping passes every validation check;
-  # required before turnover / chemo uploads are considered ready.
   mapping_valid = reactiveVal(FALSE)
 
   get_template = function() if (!is.null(app_template)) app_template() else NULL
@@ -189,9 +189,6 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
   })
 
   # ---- Parse + validate uploaded CSVs ----
-  # fread returns a data.table by default (feedback_fread_default_type); columns
-  # are validated by name, not position. GROUP is coerced to a factor so
-  # stat-analysis can derive the condition list from levels(GROUP).
 
   observeEvent(input$upload_feature_level, {
     file = input$upload_feature_level
@@ -208,8 +205,8 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
       uploaded_feature_level(NULL)
       return()
     }
-    missing = qc_missing_upload_columns(colnames(parsed),
-                                        qc_required_feature_columns(get_template()))
+    missing = get_missing_upload_columns(colnames(parsed),
+                                        get_qc_required_feature_columns())
     if (length(missing) > 0) {
       showNotification(
         paste0("FeatureLevelData is missing required column(s): ",
@@ -242,8 +239,8 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
       uploaded_protein_level(NULL)
       return()
     }
-    missing = qc_missing_upload_columns(colnames(parsed),
-                                        qc_required_protein_columns(get_template()))
+    missing = get_missing_upload_columns(colnames(parsed),
+                                        get_qc_required_protein_columns(get_template()))
     if (length(missing) > 0) {
       showNotification(
         paste0("ProteinLevelData is missing required column(s): ",
@@ -266,15 +263,11 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
   })
 
   # ---- Mapping CSV: GROUP -> time/dose, written into condition_metadata ----
-  # Turnover uses GROUP + TimeVal; chemo uses GROUP + DoseVal + DoseUnit +
-  # DrugName. GROUP is renamed to Condition so downstream turnover / chemo code
-  # consumes it unchanged.
 
   observeEvent(input$upload_condition_mapping, {
     file = input$upload_condition_mapping
     req(file)
     template = get_template()
-    # Clear validity on every (re-)upload; only a fully validated mapping sets it.
     mapping_valid(FALSE)
     parsed = tryCatch(
       data.table::fread(file$datapath),
@@ -286,8 +279,8 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
     )
     if (is.null(parsed)) return()
 
-    missing = qc_missing_upload_columns(colnames(parsed),
-                                        qc_required_mapping_columns(template))
+    missing = get_missing_upload_columns(colnames(parsed),
+                                        get_qc_required_mapping_columns(template))
     if (length(missing) > 0) {
       showNotification(
         paste0("GROUP mapping is missing required column(s): ",
@@ -296,8 +289,6 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
       return()
     }
 
-    # Value column must be numeric-coercible: blank / non-numeric entries become
-    # NA downstream and fail the fit silently.
     value_col = if (!is.null(template) && template == TEMPLATES$protein_turnover) "TimeVal" else "DoseVal"
     if (any(is.na(suppressWarnings(as.numeric(parsed[[value_col]]))))) {
       showNotification(
@@ -307,8 +298,6 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
       return()
     }
 
-    # Chemo dose units feed convert_dose_to_molar, which silently treats an
-    # unrecognized unit as molar; reject unknown units up front.
     if (!is.null(template) && template == TEMPLATES$chemoproteomics &&
         !qc_dose_units_valid(parsed$DoseUnit)) {
       showNotification(
@@ -317,8 +306,6 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
       return()
     }
 
-    # GROUP values must line up one-to-one with the uploaded ProteinLevelData;
-    # unknown groups, missing groups, or duplicate rows all corrupt the join.
     pld = uploaded_protein_level()
     if (is.null(pld)) {
       showNotification("Please upload ProteinLevelData before the GROUP mapping.",
@@ -360,7 +347,7 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
       uploaded_turnover_ratios(NULL)
       return()
     }
-    missing = qc_missing_upload_columns(colnames(parsed), qc_required_ratios_columns())
+    missing = get_missing_upload_columns(colnames(parsed), get_qc_required_ratios_columns())
     if (length(missing) > 0) {
       showNotification(
         paste0("Turnover Ratios is missing required column(s): ",
@@ -369,9 +356,16 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
       uploaded_turnover_ratios(NULL)
       return()
     }
-    if (!qc_values_numeric_finite(parsed, c("TimeVal", "H_frac", "L_frac"))) {
+    if (!qc_values_numeric_finite(parsed, "TimeVal")) {
       showNotification(
-        "Turnover Ratios TimeVal, H_frac, and L_frac must be numeric and finite for every row.",
+        "Turnover Ratios TimeVal must be numeric and finite for every row.",
+        type = "error", duration = 10)
+      uploaded_turnover_ratios(NULL)
+      return()
+    }
+    if (!qc_values_numeric_finite(parsed, c("H_frac", "L_frac"), allow_na = TRUE)) {
+      showNotification(
+        "Turnover Ratios H_frac and L_frac must be numeric and finite, or left blank.",
         type = "error", duration = 10)
       uploaded_turnover_ratios(NULL)
       return()
@@ -385,8 +379,6 @@ register_qc_data_upload <- function(input, output, session, loadpage_input,
   })
 
   # ---- Effective preprocess: uploaded tables when the load page was not used ----
-  # Falls back to the raw preprocess_data() eventReactive whenever load-page data
-  # exists or the uploads are incomplete, so existing flows are unchanged.
 
   effective_preprocess_data = reactive({
     loaded = tryCatch(get_data(), error = function(e) NULL)

--- a/R/qc-server-downloads.R
+++ b/R/qc-server-downloads.R
@@ -5,7 +5,9 @@
 #' @noRd
 register_qc_downloads <- function(input, output, session, loadpage_input, preprocess_data) {
 
-  observeEvent(input$run,{
+  # Keyed on the effective (computed OR uploaded) data, so downloads become
+  # clickable on the upload path where input$run never fires.
+  observeEvent(preprocess_data(),{
 
     if(loadpage_input()$BIO=="PTM"){
       enable("prep_feature_level_data_csv_ptm")

--- a/R/qc-server-downloads.R
+++ b/R/qc-server-downloads.R
@@ -5,8 +5,6 @@
 #' @noRd
 register_qc_downloads <- function(input, output, session, loadpage_input, preprocess_data) {
 
-  # Keyed on the effective (computed OR uploaded) data, so downloads become
-  # clickable on the upload path where input$run never fires.
   observeEvent(preprocess_data(),{
 
     if(loadpage_input()$BIO=="PTM"){

--- a/R/qc-server-plots.R
+++ b/R/qc-server-plots.R
@@ -1,15 +1,6 @@
 # QC Summarization Plots tab: plot-type and protein selectors, the
 # profile/QC/quality-metric plot builders, and the plot output.
 
-#' Whether a summarized data object carries usable feature-level data.
-#'
-#' MSstats::dataProcessPlots reads FeatureLevelData (the ABUNDANCE column), which
-#' protein-turnover uploads omit, so the QC plots gate on this before plotting.
-#' @noRd
-qc_has_feature_level <- function(data) {
-  !is.null(data$FeatureLevelData) && nrow(data$FeatureLevelData) > 0
-}
-
 #' Register the QC Summarization Plots tab outputs.
 #' @noRd
 register_qc_plots <- function(input, output, session, loadpage_input, get_data,
@@ -74,15 +65,9 @@ register_qc_plots <- function(input, output, session, loadpage_input, get_data,
     if (input$qc_page_plot_type == "QualityMetricsPlot") {
       return(NULL)
     }
-    # Upload path: get_data() is NULL (load page bypassed), so fall back to the
-    # protein list from the data being analyzed. Raw get_data() uses ProteinName;
-    # summarized ProteinLevelData uses Protein.
-    protein_choices <- tryCatch(unique(get_data()$ProteinName), error = function(e) NULL)
-    if (is.null(protein_choices) || length(protein_choices) == 0) {
-      protein_choices <- tryCatch(
-        unique(as.character(preprocess_data()$ProteinLevelData$Protein)),
-        error = function(e) NULL)
-    }
+    protein_choices <- tryCatch(
+      unique(as.character(preprocess_data()$ProteinLevelData$Protein)),
+      error = function(e) NULL)
     if ((loadpage_input()$BIO!="PTM" && input$qc_page_plot_type == "QCPlot")) {
       req(length(protein_choices) > 0)
       selectizeInput(ns("which_protein_for_data_process_plots"), "Show plot for",
@@ -173,25 +158,6 @@ register_qc_plots <- function(input, output, session, loadpage_input, get_data,
 
   output$showplot = renderUI({
     ns<- session$ns
-    # Non-PTM/non-TMT (LF) profile/QC plots need feature-level data: MSstats
-    # dataProcessPlots reads FeatureLevelData$ABUNDANCE. Protein-turnover uploads
-    # bring only ProteinLevelData, so show a message instead of crashing. Scope to
-    # LF because PTM keeps its feature data under $PTM, so its NULL top-level
-    # FeatureLevelData is expected and must not be gated. Read the effective
-    # preprocess_data() (not ordered_preprocess_data(), which re-levels GROUP and
-    # would mutate a NULL FeatureLevelData into a malformed object).
-    is_lf <- !isTRUE(loadpage_input()$BIO == "PTM") &&
-      !isTRUE(loadpage_input()$DDA_DIA == "TMT")
-    lf_data <- tryCatch(preprocess_data(), error = function(e) NULL)
-    if (isTRUE(is_lf) && !is.null(lf_data$ProteinLevelData) &&
-        !qc_has_feature_level(lf_data)) {
-      return(tags$div(
-        tags$p(paste("Profile and QC plots are not available for protein-turnover",
-                     "uploads because no feature-level data was uploaded. The turnover",
-                     "dose-response fit uses the uploaded ratios directly on the",
-                     "Statistical Inference Page."))
-      ))
-    }
     output$theplot = renderPlotly(theplot())
     op <- div(
       style = "overflow-x: auto; width: 100%;",

--- a/R/qc-server-plots.R
+++ b/R/qc-server-plots.R
@@ -189,7 +189,7 @@ register_qc_plots <- function(input, output, session, loadpage_input, get_data,
         tags$p(paste("Profile and QC plots are not available for protein-turnover",
                      "uploads because no feature-level data was uploaded. The turnover",
                      "dose-response fit uses the uploaded ratios directly on the",
-                     "Statistical Inference page."))
+                     "Statistical Inference Page."))
       ))
     }
     output$theplot = renderPlotly(theplot())

--- a/R/qc-server-plots.R
+++ b/R/qc-server-plots.R
@@ -1,6 +1,15 @@
 # QC Summarization Plots tab: plot-type and protein selectors, the
 # profile/QC/quality-metric plot builders, and the plot output.
 
+#' Whether a summarized data object carries usable feature-level data.
+#'
+#' MSstats::dataProcessPlots reads FeatureLevelData (the ABUNDANCE column), which
+#' protein-turnover uploads omit, so the QC plots gate on this before plotting.
+#' @noRd
+qc_has_feature_level <- function(data) {
+  !is.null(data$FeatureLevelData) && nrow(data$FeatureLevelData) > 0
+}
+
 #' Register the QC Summarization Plots tab outputs.
 #' @noRd
 register_qc_plots <- function(input, output, session, loadpage_input, get_data,
@@ -65,10 +74,19 @@ register_qc_plots <- function(input, output, session, loadpage_input, get_data,
     if (input$qc_page_plot_type == "QualityMetricsPlot") {
       return(NULL)
     }
+    # Upload path: get_data() is NULL (load page bypassed), so fall back to the
+    # protein list from the data being analyzed. Raw get_data() uses ProteinName;
+    # summarized ProteinLevelData uses Protein.
+    protein_choices <- tryCatch(unique(get_data()$ProteinName), error = function(e) NULL)
+    if (is.null(protein_choices) || length(protein_choices) == 0) {
+      protein_choices <- tryCatch(
+        unique(as.character(preprocess_data()$ProteinLevelData$Protein)),
+        error = function(e) NULL)
+    }
     if ((loadpage_input()$BIO!="PTM" && input$qc_page_plot_type == "QCPlot")) {
+      req(length(protein_choices) > 0)
       selectizeInput(ns("which_protein_for_data_process_plots"), "Show plot for",
-                     choices = c("", "ALL PROTEINS" = "allonly",
-                                 unique(get_data()$ProteinName)))
+                     choices = c("", "ALL PROTEINS" = "allonly", protein_choices))
     } else if (loadpage_input()$BIO == "PTM"){
       if (input$qc_page_plot_type == "QCPlot"){
         selectizeInput(ns("which_protein_for_data_process_plots"), "Show plot for",
@@ -79,8 +97,9 @@ register_qc_plots <- function(input, output, session, loadpage_input, get_data,
                        choices = c("", unique(get_data()$PTM$ProteinName)))
       }
     } else {
+      req(length(protein_choices) > 0)
       selectizeInput(ns("which_protein_for_data_process_plots"), "Show plot for",
-                     choices = c("", unique(get_data()$ProteinName)))
+                     choices = c("", protein_choices))
     }
   })
 
@@ -154,6 +173,25 @@ register_qc_plots <- function(input, output, session, loadpage_input, get_data,
 
   output$showplot = renderUI({
     ns<- session$ns
+    # Non-PTM/non-TMT (LF) profile/QC plots need feature-level data: MSstats
+    # dataProcessPlots reads FeatureLevelData$ABUNDANCE. Protein-turnover uploads
+    # bring only ProteinLevelData, so show a message instead of crashing. Scope to
+    # LF because PTM keeps its feature data under $PTM, so its NULL top-level
+    # FeatureLevelData is expected and must not be gated. Read the effective
+    # preprocess_data() (not ordered_preprocess_data(), which re-levels GROUP and
+    # would mutate a NULL FeatureLevelData into a malformed object).
+    is_lf <- !isTRUE(loadpage_input()$BIO == "PTM") &&
+      !isTRUE(loadpage_input()$DDA_DIA == "TMT")
+    lf_data <- tryCatch(preprocess_data(), error = function(e) NULL)
+    if (isTRUE(is_lf) && !is.null(lf_data$ProteinLevelData) &&
+        !qc_has_feature_level(lf_data)) {
+      return(tags$div(
+        tags$p(paste("Profile and QC plots are not available for protein-turnover",
+                     "uploads because no feature-level data was uploaded. The turnover",
+                     "dose-response fit uses the uploaded ratios directly on the",
+                     "Statistical Inference page."))
+      ))
+    }
     output$theplot = renderPlotly(theplot())
     op <- div(
       style = "overflow-x: auto; width: 100%;",

--- a/R/statmodel-server-comparisons.R
+++ b/R/statmodel-server-comparisons.R
@@ -68,12 +68,11 @@ autofill_condition_value <- function(conditions) {
 #' @return Character vector of condition levels
 #' @noRd
 get_experimental_conditions = function(loadpage_input, preprocess_data) {
-  if (isTRUE(loadpage_input$BIO == "PTM") &
-      ((isTRUE(loadpage_input$BIO == "PTM") & isTRUE(loadpage_input$DDA_DIA == "TMT")) |
-       isTRUE(loadpage_input$filetype == 'phil'))) {
+  if (isTRUE(loadpage_input$BIO == "PTM") &&
+      (isTRUE(loadpage_input$DDA_DIA == "TMT") ||
+       isTRUE(loadpage_input$filetype == "phil"))) {
     levels(preprocess_data$PTM$ProteinLevelData$Condition)
-  } else if (isTRUE(loadpage_input$BIO == "PTM") &
-             (isTRUE(loadpage_input$BIO == "PTM") & isTRUE(loadpage_input$DDA_DIA != "TMT"))) {
+  } else if (isTRUE(loadpage_input$BIO == "PTM")) {
     levels(preprocess_data$PTM$ProteinLevelData$GROUP)
   } else if (isTRUE(loadpage_input$DDA_DIA == "TMT")) {
     levels(preprocess_data$ProteinLevelData$Condition)

--- a/R/statmodel-server-comparisons.R
+++ b/R/statmodel-server-comparisons.R
@@ -68,14 +68,14 @@ autofill_condition_value <- function(conditions) {
 #' @return Character vector of condition levels
 #' @noRd
 get_experimental_conditions = function(loadpage_input, preprocess_data) {
-  if (loadpage_input$BIO == "PTM" & 
-      ((loadpage_input$BIO == "PTM" & loadpage_input$DDA_DIA == "TMT") | 
-       loadpage_input$filetype == 'phil')) {
+  if (isTRUE(loadpage_input$BIO == "PTM") &
+      ((isTRUE(loadpage_input$BIO == "PTM") & isTRUE(loadpage_input$DDA_DIA == "TMT")) |
+       isTRUE(loadpage_input$filetype == 'phil'))) {
     levels(preprocess_data$PTM$ProteinLevelData$Condition)
-  } else if (loadpage_input$BIO == "PTM" & 
-             (loadpage_input$BIO == "PTM" & loadpage_input$DDA_DIA != "TMT")) {
+  } else if (isTRUE(loadpage_input$BIO == "PTM") &
+             (isTRUE(loadpage_input$BIO == "PTM") & isTRUE(loadpage_input$DDA_DIA != "TMT"))) {
     levels(preprocess_data$PTM$ProteinLevelData$GROUP)
-  } else if (loadpage_input$DDA_DIA == "TMT") {
+  } else if (isTRUE(loadpage_input$DDA_DIA == "TMT")) {
     levels(preprocess_data$ProteinLevelData$Condition)
   } else {
     levels(preprocess_data$ProteinLevelData$GROUP)

--- a/R/statmodel-server-download-code.R
+++ b/R/statmodel-server-download-code.R
@@ -119,8 +119,8 @@ generate_analysis_code = function(qc_input, loadpage_input, comp_mat, input, app
                        remove_empty_channel = TRUE
                        )\n", sep = "")
   } else if (loadpage_input$BIO == "PTM") {
-    dt = if ((loadpage_input$BIO == "PTM" & loadpage_input$DDA_DIA == "TMT") | 
-             loadpage_input$filetype == 'phil') "TMT" else "LabelFree"
+    dt = if ((isTRUE(loadpage_input$BIO == "PTM") & isTRUE(loadpage_input$DDA_DIA == "TMT")) |
+             isTRUE(loadpage_input$filetype == 'phil')) "TMT" else "LabelFree"
     
     codes = paste(codes, "\n# Model-based comparison\n", sep = "")
     codes = paste(codes, "model = MSstatsPTM::groupComparisonPTM(summarized, '",

--- a/R/statmodel-server-download-code.R
+++ b/R/statmodel-server-download-code.R
@@ -109,7 +109,15 @@ generate_analysis_code = function(qc_input, loadpage_input, comp_mat, input, app
   codes = paste(codes, "colnames(contrast.matrix)=c(\"", 
                 paste(colnames(comp_mat), collapse = '","'), "\")\n", sep = "")
   
-  if (loadpage_input$DDA_DIA == "TMT") {
+  if (isTRUE(loadpage_input$BIO == "PTM")) {
+    dt = if ((isTRUE(loadpage_input$BIO == "PTM") & isTRUE(loadpage_input$DDA_DIA == "TMT")) |
+             isTRUE(loadpage_input$filetype == 'phil')) "TMT" else "LabelFree"
+
+    codes = paste(codes, "\n# Model-based comparison\n", sep = "")
+    codes = paste(codes, "model = MSstatsPTM::groupComparisonPTM(summarized, '",
+                  dt, "', \t\t\t\t
+                      contrast.matrix = contrast.matrix)\n", sep = "")
+  } else if (isTRUE(loadpage_input$DDA_DIA == "TMT")) {
     codes = paste(codes, "\n# Model-based comparison\n", sep = "")
     codes = paste(codes, "model = MSstatsTMT::groupComparisonTMT(summarized,
                        contrast.matrix = contrast.matrix,
@@ -118,14 +126,6 @@ generate_analysis_code = function(qc_input, loadpage_input, comp_mat, input, app
                        remove_norm_channel = TRUE,
                        remove_empty_channel = TRUE
                        )\n", sep = "")
-  } else if (loadpage_input$BIO == "PTM") {
-    dt = if ((isTRUE(loadpage_input$BIO == "PTM") & isTRUE(loadpage_input$DDA_DIA == "TMT")) |
-             isTRUE(loadpage_input$filetype == 'phil')) "TMT" else "LabelFree"
-    
-    codes = paste(codes, "\n# Model-based comparison\n", sep = "")
-    codes = paste(codes, "model = MSstatsPTM::groupComparisonPTM(summarized, '",
-                  dt, "', \t\t\t\t
-                      contrast.matrix = contrast.matrix)\n", sep = "")
   } else {
     codes = paste(codes, "\n# Model-based comparison\n", sep = "")
     codes = paste(codes, "model = MSstats::groupComparison(contrast.matrix, summarized)\n", sep = "")

--- a/R/statmodel-server-visualization.R
+++ b/R/statmodel-server-visualization.R
@@ -2,7 +2,7 @@
 # Visualization Options and Plotting Functions
 # ============================================================================
 
-render_group_comparison_plot_inputs = function(output, session, rownames, get_data, input, loadpage_input, condition_list, contrast, app_template = reactive(TEMPLATES$default), condition_metadata = reactive(NULL)) {
+render_group_comparison_plot_inputs = function(output, session, rownames, get_data, input, loadpage_input, condition_list, contrast, app_template = reactive(TEMPLATES$default), condition_metadata = reactive(NULL), preprocess_data = reactive(NULL)) {
   ns = session$ns
   
   output[[NAMESPACE_STATMODEL$visualization_which_comparison]] = renderUI({
@@ -28,9 +28,19 @@ render_group_comparison_plot_inputs = function(output, session, rownames, get_da
   })
   
   output[[NAMESPACE_STATMODEL$visualization_which_protein]] = renderUI({
+    proteins = tryCatch(unique(get_data()$ProteinName), error = function(e) NULL)
+    if (is.null(proteins) || length(proteins) == 0) {
+      # Upload path: the load page was bypassed (get_data() is NULL), so source
+      # the protein list from the data actually being analyzed. This matches the
+      # protein values the response-curve plot filters on (dia_prepared$protein,
+      # derived from ProteinLevelData$Protein).
+      proteins = tryCatch(unique(as.character(preprocess_data()$ProteinLevelData$Protein)),
+                          error = function(e) NULL)
+    }
+    req(length(proteins) > 0)
     selectInput(ns(NAMESPACE_STATMODEL$visualization_which_protein),
-                label = h4("which protein to plot"), 
-                unique(get_data()$ProteinName))
+                label = h4("which protein to plot"),
+                proteins)
   })
   
   output[[NAMESPACE_STATMODEL$visualization_plot_options_conditional_panel]] = renderUI({

--- a/R/statmodel-server-visualization.R
+++ b/R/statmodel-server-visualization.R
@@ -28,15 +28,8 @@ render_group_comparison_plot_inputs = function(output, session, rownames, get_da
   })
   
   output[[NAMESPACE_STATMODEL$visualization_which_protein]] = renderUI({
-    proteins = tryCatch(unique(get_data()$ProteinName), error = function(e) NULL)
-    if (is.null(proteins) || length(proteins) == 0) {
-      # Upload path: the load page was bypassed (get_data() is NULL), so source
-      # the protein list from the data actually being analyzed. This matches the
-      # protein values the response-curve plot filters on (dia_prepared$protein,
-      # derived from ProteinLevelData$Protein).
-      proteins = tryCatch(unique(as.character(preprocess_data()$ProteinLevelData$Protein)),
-                          error = function(e) NULL)
-    }
+    proteins = tryCatch(unique(as.character(preprocess_data()$ProteinLevelData$Protein)),
+                        error = function(e) NULL)
     req(length(proteins) > 0)
     selectInput(ns(NAMESPACE_STATMODEL$visualization_which_protein),
                 label = h4("which protein to plot"),

--- a/R/utils.R
+++ b/R/utils.R
@@ -1939,7 +1939,7 @@ dataComparison <- function(statmodel_input,qc_input,loadpage_input,matrix,input_
   print("+++++++++ In Data Comparison +++++++++")
   # input_data = preprocessData(qc_input,loadpage_input,get_data())
   contrast.matrix = matrix
-  if (loadpage_input$BIO == "PTM" & ((loadpage_input$BIO == "PTM" & loadpage_input$DDA_DIA == "TMT" ) | loadpage_input$filetype=='phil')){
+  if (isTRUE(loadpage_input$BIO == "PTM") & ((isTRUE(loadpage_input$BIO == "PTM") & isTRUE(loadpage_input$DDA_DIA == "TMT")) | isTRUE(loadpage_input$filetype=='phil'))){
     model_ptm = MSstatsShiny::tmt_model(input_data$PTM, statmodel_input, contrast.matrix)
     model_protein = MSstatsShiny::tmt_model(input_data$PROTEIN, statmodel_input, contrast.matrix)
     model_adj = MSstatsShiny::apply_adj(model_ptm$ComparisonResult,
@@ -1948,7 +1948,7 @@ dataComparison <- function(statmodel_input,qc_input,loadpage_input,matrix,input_
                  'PROTEIN.Model' = model_protein$ComparisonResult,
                  'ADJUSTED.Model' = model_adj)
 
-  } else if(loadpage_input$BIO == "PTM" & (loadpage_input$BIO == "PTM" & loadpage_input$DDA_DIA != "TMT" )){
+  } else if(isTRUE(loadpage_input$BIO == "PTM") & (isTRUE(loadpage_input$BIO == "PTM") & isTRUE(loadpage_input$DDA_DIA != "TMT"))){
     model_ptm = MSstatsShiny::lf_model(input_data$PTM, contrast.matrix)
     model_protein = MSstatsShiny::lf_model(input_data$PROTEIN, contrast.matrix)
     model_adj = MSstatsShiny::apply_adj(model_ptm$ComparisonResult,
@@ -1957,7 +1957,7 @@ dataComparison <- function(statmodel_input,qc_input,loadpage_input,matrix,input_
                  'PROTEIN.Model' = model_protein$ComparisonResult,
                  'ADJUSTED.Model' = model_adj)
 
-  } else if(loadpage_input$DDA_DIA=="TMT"){
+  } else if(isTRUE(loadpage_input$DDA_DIA=="TMT")){
     model = MSstatsShiny::tmt_model(input_data, statmodel_input, contrast.matrix)
   }
   else{

--- a/R/utils.R
+++ b/R/utils.R
@@ -1803,13 +1803,13 @@ preprocessData <- function(qc_input,loadpage_input,input_data ) {
   MSstatsLogsSettings(FALSE)
   ## Here we run the underlying functions for MSstats and MSstatsTMT
   ## summarization. Done so we can loop over proteins and create a progress bar
-  if(isTRUE(loadpage_input$BIO == "PTM") & ((isTRUE(loadpage_input$BIO == "PTM") & isTRUE(loadpage_input$DDA_DIA == "TMT")) | isTRUE(loadpage_input$filetype=='phil'))){
+  if (isTRUE(loadpage_input$BIO == "PTM") && (isTRUE(loadpage_input$DDA_DIA == "TMT") || isTRUE(loadpage_input$filetype == "phil"))) {
 
     preprocessed_ptm = MSstatsShiny::tmt_summarization_loop(input_data$PTM, qc_input,loadpage_input)
     preprocessed_unmod = MSstatsShiny::tmt_summarization_loop(input_data$PROTEIN, qc_input,loadpage_input)
     preprocessed = list(PTM = preprocessed_ptm, PROTEIN = preprocessed_unmod)
 
-  } else if (isTRUE(loadpage_input$BIO == "PTM") & (isTRUE(loadpage_input$BIO == "PTM") & isTRUE(loadpage_input$DDA_DIA != "TMT"))){
+  } else if (isTRUE(loadpage_input$BIO == "PTM")) {
 
     preprocessed_ptm = MSstatsShiny::lf_summarization_loop(input_data$PTM, qc_input, loadpage_input)
     preprocessed_unmod = MSstatsShiny::lf_summarization_loop(input_data$PROTEIN, qc_input, loadpage_input)
@@ -1833,7 +1833,7 @@ preprocessDataCode <- function(qc_input,loadpage_input) {
   codes = getDataCode(loadpage_input)
 
   if (isTRUE(loadpage_input$BIO == "PTM")){
-    if ((isTRUE(loadpage_input$BIO == "PTM") & isTRUE(loadpage_input$DDA_DIA == "TMT")) | isTRUE(loadpage_input$filetype=='phil')){
+    if (isTRUE(loadpage_input$DDA_DIA == "TMT") || isTRUE(loadpage_input$filetype == "phil")) {
       codes = paste(codes, "\n# use MSstats for protein summarization\n", sep = "")
       codes = paste(codes, "summarized = MSstatsPTM::dataSummarizationPTM_TMT(data,
                      method = '",qc_input$summarization,"\',\t\t\t\t
@@ -1939,7 +1939,7 @@ dataComparison <- function(statmodel_input,qc_input,loadpage_input,matrix,input_
   print("+++++++++ In Data Comparison +++++++++")
   # input_data = preprocessData(qc_input,loadpage_input,get_data())
   contrast.matrix = matrix
-  if (isTRUE(loadpage_input$BIO == "PTM") & ((isTRUE(loadpage_input$BIO == "PTM") & isTRUE(loadpage_input$DDA_DIA == "TMT")) | isTRUE(loadpage_input$filetype=='phil'))){
+  if (isTRUE(loadpage_input$BIO == "PTM") && (isTRUE(loadpage_input$DDA_DIA == "TMT") || isTRUE(loadpage_input$filetype == "phil"))) {
     model_ptm = MSstatsShiny::tmt_model(input_data$PTM, statmodel_input, contrast.matrix)
     model_protein = MSstatsShiny::tmt_model(input_data$PROTEIN, statmodel_input, contrast.matrix)
     model_adj = MSstatsShiny::apply_adj(model_ptm$ComparisonResult,
@@ -1948,7 +1948,7 @@ dataComparison <- function(statmodel_input,qc_input,loadpage_input,matrix,input_
                  'PROTEIN.Model' = model_protein$ComparisonResult,
                  'ADJUSTED.Model' = model_adj)
 
-  } else if(isTRUE(loadpage_input$BIO == "PTM") & (isTRUE(loadpage_input$BIO == "PTM") & isTRUE(loadpage_input$DDA_DIA != "TMT"))){
+  } else if (isTRUE(loadpage_input$BIO == "PTM")) {
     model_ptm = MSstatsShiny::lf_model(input_data$PTM, contrast.matrix)
     model_protein = MSstatsShiny::lf_model(input_data$PROTEIN, contrast.matrix)
     model_adj = MSstatsShiny::apply_adj(model_ptm$ComparisonResult,

--- a/R/utils.R
+++ b/R/utils.R
@@ -1803,19 +1803,19 @@ preprocessData <- function(qc_input,loadpage_input,input_data ) {
   MSstatsLogsSettings(FALSE)
   ## Here we run the underlying functions for MSstats and MSstatsTMT
   ## summarization. Done so we can loop over proteins and create a progress bar
-  if(loadpage_input$BIO == "PTM" & ((loadpage_input$BIO == "PTM" & loadpage_input$DDA_DIA == "TMT" ) | loadpage_input$filetype=='phil')){
+  if(isTRUE(loadpage_input$BIO == "PTM") & ((isTRUE(loadpage_input$BIO == "PTM") & isTRUE(loadpage_input$DDA_DIA == "TMT")) | isTRUE(loadpage_input$filetype=='phil'))){
 
     preprocessed_ptm = MSstatsShiny::tmt_summarization_loop(input_data$PTM, qc_input,loadpage_input)
     preprocessed_unmod = MSstatsShiny::tmt_summarization_loop(input_data$PROTEIN, qc_input,loadpage_input)
     preprocessed = list(PTM = preprocessed_ptm, PROTEIN = preprocessed_unmod)
 
-  } else if (loadpage_input$BIO == "PTM" & (loadpage_input$BIO == "PTM" & loadpage_input$DDA_DIA != "TMT" )){
+  } else if (isTRUE(loadpage_input$BIO == "PTM") & (isTRUE(loadpage_input$BIO == "PTM") & isTRUE(loadpage_input$DDA_DIA != "TMT"))){
 
     preprocessed_ptm = MSstatsShiny::lf_summarization_loop(input_data$PTM, qc_input, loadpage_input)
     preprocessed_unmod = MSstatsShiny::lf_summarization_loop(input_data$PROTEIN, qc_input, loadpage_input)
     preprocessed = list(PTM = preprocessed_ptm, PROTEIN = preprocessed_unmod)
 
-  } else if(loadpage_input$DDA_DIA == "TMT"){
+  } else if(isTRUE(loadpage_input$DDA_DIA == "TMT")){
 
     ## Run MSstatsTMT summarization
     preprocessed = MSstatsShiny::tmt_summarization_loop(input_data, qc_input,loadpage_input)
@@ -1832,28 +1832,8 @@ preprocessDataCode <- function(qc_input,loadpage_input) {
 
   codes = getDataCode(loadpage_input)
 
-  if(loadpage_input$DDA_DIA == "TMT"){
-
-    codes = paste(codes, "\n# use MSstats for protein summarization\n", sep = "")
-    codes = paste(codes, "summarized = MSstatsTMT::proteinSummarization(data,
-                   method = '",qc_input$summarization,"\',\t\t\t\t
-                   global_norm = ", qc_input$global_norm,",\t\t\t\t
-                   reference_norm = ", qc_input$reference_norm,",\t\t\t\t
-                   remove_norm_channel  = ", qc_input$remove_norm_channel,",\t\t\t\t
-                   remove_empty_channel = TRUE, \t\t\t\t
-                   MBimpute = FALSE, \t\t\t\t
-                   maxQuantileforCensored = ", qc_input$maxQC1,")\n", sep = "")
-    codes = paste(codes, "\n# use to create data summarization plots\n", sep = "")
-    codes = paste(codes, "dataProcessPlotsTMT(summarized,
-                            type= \"Enter ProfilePlot or QCPlot Here\",
-                            ylimUp = FALSE,
-                            ylimDown = FALSE,
-                            which.Protein = \"Enter Protein to Plot Here\",
-                            originalPlot = TRUE,
-                            summaryPlot =", qc_input$summ,",\t\t\t\t
-                            address = FALSE)\n", sep="")
-  } else if (loadpage_input$BIO == "PTM"){
-    if ((loadpage_input$BIO == "PTM" & loadpage_input$DDA_DIA == "TMT" ) | loadpage_input$filetype=='phil'){
+  if (isTRUE(loadpage_input$BIO == "PTM")){
+    if ((isTRUE(loadpage_input$BIO == "PTM") & isTRUE(loadpage_input$DDA_DIA == "TMT")) | isTRUE(loadpage_input$filetype=='phil')){
       codes = paste(codes, "\n# use MSstats for protein summarization\n", sep = "")
       codes = paste(codes, "summarized = MSstatsPTM::dataSummarizationPTM_TMT(data,
                      method = '",qc_input$summarization,"\',\t\t\t\t
@@ -1883,6 +1863,26 @@ preprocessDataCode <- function(qc_input,loadpage_input) {
                             ylimUp = FALSE,
                             ylimDown = FALSE,
                             which.PTM = \"Enter PTM to Plot Here\",
+                            originalPlot = TRUE,
+                            summaryPlot =", qc_input$summ,",\t\t\t\t
+                            address = FALSE)\n", sep="")
+  } else if(isTRUE(loadpage_input$DDA_DIA == "TMT")){
+
+    codes = paste(codes, "\n# use MSstats for protein summarization\n", sep = "")
+    codes = paste(codes, "summarized = MSstatsTMT::proteinSummarization(data,
+                   method = '",qc_input$summarization,"\',\t\t\t\t
+                   global_norm = ", qc_input$global_norm,",\t\t\t\t
+                   reference_norm = ", qc_input$reference_norm,",\t\t\t\t
+                   remove_norm_channel  = ", qc_input$remove_norm_channel,",\t\t\t\t
+                   remove_empty_channel = TRUE, \t\t\t\t
+                   MBimpute = FALSE, \t\t\t\t
+                   maxQuantileforCensored = ", qc_input$maxQC1,")\n", sep = "")
+    codes = paste(codes, "\n# use to create data summarization plots\n", sep = "")
+    codes = paste(codes, "dataProcessPlotsTMT(summarized,
+                            type= \"Enter ProfilePlot or QCPlot Here\",
+                            ylimUp = FALSE,
+                            ylimDown = FALSE,
+                            which.Protein = \"Enter Protein to Plot Here\",
                             originalPlot = TRUE,
                             summaryPlot =", qc_input$summ,",\t\t\t\t
                             address = FALSE)\n", sep="")

--- a/tests/testthat/test-qc-data-upload.R
+++ b/tests/testthat/test-qc-data-upload.R
@@ -59,11 +59,54 @@ test_that("qc_uploads_complete needs both feature and protein tables (default/ch
   expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$chemoproteomics, FALSE, TRUE, FALSE))
 })
 
-test_that("qc_uploads_complete turnover branch is currently a two-file stub", {
-  # Commit 2 will fold in uploaded ratios / metadata; for now it mirrors the
-  # default rule and ignores has_turnover.
+test_that("qc_uploads_complete turnover needs protein + ratios (feature optional)", {
+  # Turnover consumes the uploaded ratios table directly; FeatureLevelData is not
+  # used on the response-curve path, so protein + ratios is sufficient.
+  expect_true(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, FALSE, TRUE, TRUE))
   expect_true(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, TRUE, TRUE, TRUE))
-  expect_true(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, TRUE, TRUE, FALSE))
+
+  # Missing ratios or protein leaves it incomplete; feature alone is not enough.
+  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, TRUE, TRUE, FALSE))
   expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, TRUE, FALSE, TRUE))
-  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, FALSE, TRUE, TRUE))
+  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, TRUE, FALSE, FALSE))
+})
+
+test_that("qc_required_mapping_columns is template-specific", {
+  expect_equal(MSstatsShiny:::qc_required_mapping_columns(TEMPLATES$protein_turnover),
+               c("GROUP", "TimeVal"))
+  expect_equal(MSstatsShiny:::qc_required_mapping_columns(TEMPLATES$chemoproteomics),
+               c("GROUP", "DoseVal"))
+  expect_equal(MSstatsShiny:::qc_required_mapping_columns(TEMPLATES$default), character(0))
+  expect_equal(MSstatsShiny:::qc_required_mapping_columns(NULL), character(0))
+})
+
+test_that("qc_required_ratios_columns matches the turnover-ratios fit inputs", {
+  expect_equal(MSstatsShiny:::qc_required_ratios_columns(),
+               c("Protein", "TimeVal", "H_frac", "L_frac"))
+})
+
+test_that("qc_mapping_to_condition_metadata renames GROUP to Condition (turnover)", {
+  parsed = data.frame(GROUP = c("0hr", "1hr"), TimeVal = c(0, 1),
+                      stringsAsFactors = FALSE)
+  out = MSstatsShiny:::qc_mapping_to_condition_metadata(parsed, TEMPLATES$protein_turnover)
+  expect_equal(colnames(out), c("Condition", "TimeVal"))
+  expect_equal(out$Condition, c("0hr", "1hr"))
+  expect_type(out$Condition, "character")
+  expect_type(out$TimeVal, "character")
+})
+
+test_that("qc_mapping_to_condition_metadata keeps optional chemo columns when present", {
+  # DoseUnit / DrugName are passed through only when present in the CSV.
+  bare = data.frame(GROUP = c("DMSO", "Drug_10nM"), DoseVal = c(0, 10),
+                    stringsAsFactors = FALSE)
+  out_bare = MSstatsShiny:::qc_mapping_to_condition_metadata(bare, TEMPLATES$chemoproteomics)
+  expect_equal(colnames(out_bare), c("Condition", "DoseVal"))
+  expect_type(out_bare$DoseVal, "character")
+
+  full = data.frame(GROUP = c("DMSO", "Drug_10nM"), DoseVal = c(0, 10),
+                    DoseUnit = c("nM", "nM"), DrugName = c("DMSO", "Drug"),
+                    stringsAsFactors = FALSE)
+  out_full = MSstatsShiny:::qc_mapping_to_condition_metadata(full, TEMPLATES$chemoproteomics)
+  expect_equal(colnames(out_full), c("Condition", "DoseVal", "DoseUnit", "DrugName"))
+  expect_type(out_full$DrugName, "character")
 })

--- a/tests/testthat/test-qc-data-upload.R
+++ b/tests/testthat/test-qc-data-upload.R
@@ -1,51 +1,48 @@
 # Truth-table tests for the QC Data Upload column-validation and
 # upload-completeness helpers (pure functions, no Shiny session required).
 
-test_that("qc_missing_upload_columns returns the required columns that are absent", {
+test_that("get_missing_upload_columns returns the required columns that are absent", {
   # All required columns present -> nothing missing.
   expect_equal(
-    MSstatsShiny:::qc_missing_upload_columns(c("A", "B", "C"), c("A", "B")),
+    MSstatsShiny:::get_missing_upload_columns(c("A", "B", "C"), c("A", "B")),
     character(0)
   )
   # Missing columns are reported in required order.
   expect_equal(
-    MSstatsShiny:::qc_missing_upload_columns(c("A", "C"), c("A", "B", "D")),
+    MSstatsShiny:::get_missing_upload_columns(c("A", "C"), c("A", "B", "D")),
     c("B", "D")
   )
   # Column order and extra present columns do not matter (name-based, not position).
   expect_equal(
-    MSstatsShiny:::qc_missing_upload_columns(c("C", "B", "A", "Z"), c("A", "B", "C")),
+    MSstatsShiny:::get_missing_upload_columns(c("C", "B", "A", "Z"), c("A", "B", "C")),
     character(0)
   )
 })
 
-test_that("qc_required_protein_columns matches the summarization output keys", {
+test_that("get_qc_required_protein_columns matches the summarization output keys", {
   expect_equal(
-    MSstatsShiny:::qc_required_protein_columns(TEMPLATES$default),
+    MSstatsShiny:::get_qc_required_protein_columns(TEMPLATES$default),
     c("Protein", "GROUP", "RUN", "LogIntensities")
   )
   expect_equal(
-    MSstatsShiny:::qc_required_protein_columns(TEMPLATES$chemoproteomics),
+    MSstatsShiny:::get_qc_required_protein_columns(TEMPLATES$chemoproteomics),
     c("Protein", "GROUP", "RUN", "LogIntensities")
   )
   # Turnover adds the heavy/light channel column.
   expect_equal(
-    MSstatsShiny:::qc_required_protein_columns(TEMPLATES$protein_turnover),
+    MSstatsShiny:::get_qc_required_protein_columns(TEMPLATES$protein_turnover),
     c("Protein", "GROUP", "RUN", "LogIntensities", "LABEL")
   )
   # A NULL template (module called without app_template) falls back to the base set.
   expect_equal(
-    MSstatsShiny:::qc_required_protein_columns(NULL),
+    MSstatsShiny:::get_qc_required_protein_columns(NULL),
     c("Protein", "GROUP", "RUN", "LogIntensities")
   )
 })
 
-test_that("qc_required_feature_columns is the MSstats feature-level key set", {
+test_that("get_qc_required_feature_columns is the MSstats feature-level key set", {
   expected = c("PROTEIN", "PEPTIDE", "FEATURE", "RUN", "GROUP", "LABEL", "INTENSITY")
-  expect_equal(MSstatsShiny:::qc_required_feature_columns(TEMPLATES$default), expected)
-  expect_equal(MSstatsShiny:::qc_required_feature_columns(TEMPLATES$chemoproteomics), expected)
-  expect_equal(MSstatsShiny:::qc_required_feature_columns(TEMPLATES$protein_turnover), expected)
-  expect_equal(MSstatsShiny:::qc_required_feature_columns(NULL), expected)
+  expect_equal(MSstatsShiny:::get_qc_required_feature_columns(), expected)
 })
 
 test_that("qc_uploads_complete needs both feature and protein tables (default)", {
@@ -67,29 +64,27 @@ test_that("qc_uploads_complete chemo needs feature + protein + valid mapping", {
   expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$chemoproteomics, FALSE, TRUE, FALSE, TRUE))
 })
 
-test_that("qc_uploads_complete turnover needs protein + ratios + mapping (feature optional)", {
-  # Turnover consumes the uploaded ratios table directly; FeatureLevelData is not
-  # used on the response-curve path, so protein + ratios + a valid mapping suffice.
-  expect_true(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, FALSE, TRUE, TRUE, TRUE))
+test_that("qc_uploads_complete turnover needs feature + protein + ratios + mapping", {
   expect_true(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, TRUE, TRUE, TRUE, TRUE))
 
-  # Missing ratios, protein, or mapping leaves it incomplete.
-  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, TRUE, TRUE, TRUE, FALSE))
-  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, TRUE, TRUE, FALSE, TRUE))
+  # Missing feature, protein, ratios, or mapping leaves it incomplete.
+  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, FALSE, TRUE, TRUE, TRUE))
   expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, TRUE, FALSE, TRUE, TRUE))
+  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, TRUE, TRUE, FALSE, TRUE))
+  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, TRUE, TRUE, TRUE, FALSE))
 })
 
-test_that("qc_required_mapping_columns is template-specific", {
-  expect_equal(MSstatsShiny:::qc_required_mapping_columns(TEMPLATES$protein_turnover),
+test_that("get_qc_required_mapping_columns is template-specific", {
+  expect_equal(MSstatsShiny:::get_qc_required_mapping_columns(TEMPLATES$protein_turnover),
                c("GROUP", "TimeVal"))
-  expect_equal(MSstatsShiny:::qc_required_mapping_columns(TEMPLATES$chemoproteomics),
+  expect_equal(MSstatsShiny:::get_qc_required_mapping_columns(TEMPLATES$chemoproteomics),
                c("GROUP", "DoseVal", "DoseUnit", "DrugName"))
-  expect_equal(MSstatsShiny:::qc_required_mapping_columns(TEMPLATES$default), character(0))
-  expect_equal(MSstatsShiny:::qc_required_mapping_columns(NULL), character(0))
+  expect_equal(MSstatsShiny:::get_qc_required_mapping_columns(TEMPLATES$default), character(0))
+  expect_equal(MSstatsShiny:::get_qc_required_mapping_columns(NULL), character(0))
 })
 
-test_that("qc_required_ratios_columns matches the turnover-ratios fit inputs", {
-  expect_equal(MSstatsShiny:::qc_required_ratios_columns(),
+test_that("get_qc_required_ratios_columns matches the turnover-ratios fit inputs", {
+  expect_equal(MSstatsShiny:::get_qc_required_ratios_columns(),
                c("Protein", "TimeVal", "H_frac", "L_frac"))
 })
 
@@ -172,4 +167,23 @@ test_that("qc_values_numeric_finite requires numeric, finite values in all colum
   expect_false(MSstatsShiny:::qc_values_numeric_finite(bad_na, c("TimeVal", "H_frac", "L_frac")))
   # Absent column.
   expect_false(MSstatsShiny:::qc_values_numeric_finite(ok, c("TimeVal", "Missing")))
+})
+
+test_that("qc_values_numeric_finite allows NA / blank when allow_na = TRUE", {
+  # Real missing values (NA and blank) pass for H_frac / L_frac.
+  with_na = data.frame(H_frac = c(0.1, NA, 0.3), L_frac = c("0.9", "", "0.7"),
+                       stringsAsFactors = FALSE)
+  expect_true(MSstatsShiny:::qc_values_numeric_finite(with_na, c("H_frac", "L_frac"),
+                                                      allow_na = TRUE))
+  # A typo (non-numeric, non-blank) is still rejected.
+  typo = data.frame(H_frac = c(0.1, 0.2, 0.3), L_frac = c("0.9", "abc", "0.7"),
+                    stringsAsFactors = FALSE)
+  expect_false(MSstatsShiny:::qc_values_numeric_finite(typo, c("H_frac", "L_frac"),
+                                                       allow_na = TRUE))
+  # Non-finite (Inf) is still rejected even with allow_na.
+  inf = data.frame(H_frac = c(0.1, Inf, 0.3), stringsAsFactors = FALSE)
+  expect_false(MSstatsShiny:::qc_values_numeric_finite(inf, "H_frac", allow_na = TRUE))
+  # allow_na does not relax the default: NA still fails without the flag.
+  na_default = data.frame(TimeVal = c(0, NA, 2), stringsAsFactors = FALSE)
+  expect_false(MSstatsShiny:::qc_values_numeric_finite(na_default, "TimeVal"))
 })

--- a/tests/testthat/test-qc-data-upload.R
+++ b/tests/testthat/test-qc-data-upload.R
@@ -1,0 +1,69 @@
+# Truth-table tests for the QC Data Upload column-validation and
+# upload-completeness helpers (pure functions, no Shiny session required).
+
+test_that("qc_missing_upload_columns returns the required columns that are absent", {
+  # All required columns present -> nothing missing.
+  expect_equal(
+    MSstatsShiny:::qc_missing_upload_columns(c("A", "B", "C"), c("A", "B")),
+    character(0)
+  )
+  # Missing columns are reported in required order.
+  expect_equal(
+    MSstatsShiny:::qc_missing_upload_columns(c("A", "C"), c("A", "B", "D")),
+    c("B", "D")
+  )
+  # Column order and extra present columns do not matter (name-based, not position).
+  expect_equal(
+    MSstatsShiny:::qc_missing_upload_columns(c("C", "B", "A", "Z"), c("A", "B", "C")),
+    character(0)
+  )
+})
+
+test_that("qc_required_protein_columns matches the summarization output keys", {
+  expect_equal(
+    MSstatsShiny:::qc_required_protein_columns(TEMPLATES$default),
+    c("Protein", "GROUP", "RUN", "LogIntensities")
+  )
+  expect_equal(
+    MSstatsShiny:::qc_required_protein_columns(TEMPLATES$chemoproteomics),
+    c("Protein", "GROUP", "RUN", "LogIntensities")
+  )
+  # Turnover adds the heavy/light channel column (consumed in commit 2).
+  expect_equal(
+    MSstatsShiny:::qc_required_protein_columns(TEMPLATES$protein_turnover),
+    c("Protein", "GROUP", "RUN", "LogIntensities", "LABEL")
+  )
+  # A NULL template (module called without app_template) falls back to the base set.
+  expect_equal(
+    MSstatsShiny:::qc_required_protein_columns(NULL),
+    c("Protein", "GROUP", "RUN", "LogIntensities")
+  )
+})
+
+test_that("qc_required_feature_columns is the MSstats feature-level key set", {
+  expected = c("PROTEIN", "PEPTIDE", "FEATURE", "RUN", "GROUP", "LABEL", "INTENSITY")
+  expect_equal(MSstatsShiny:::qc_required_feature_columns(TEMPLATES$default), expected)
+  expect_equal(MSstatsShiny:::qc_required_feature_columns(TEMPLATES$chemoproteomics), expected)
+  expect_equal(MSstatsShiny:::qc_required_feature_columns(TEMPLATES$protein_turnover), expected)
+  expect_equal(MSstatsShiny:::qc_required_feature_columns(NULL), expected)
+})
+
+test_that("qc_uploads_complete needs both feature and protein tables (default/chemo)", {
+  expect_true(MSstatsShiny:::qc_uploads_complete(TEMPLATES$default, TRUE, TRUE, FALSE))
+  expect_true(MSstatsShiny:::qc_uploads_complete(TEMPLATES$chemoproteomics, TRUE, TRUE, FALSE))
+
+  # Any single missing file leaves the upload incomplete.
+  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$default, TRUE, FALSE, FALSE))
+  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$default, FALSE, TRUE, FALSE))
+  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$default, FALSE, FALSE, FALSE))
+  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$chemoproteomics, FALSE, TRUE, FALSE))
+})
+
+test_that("qc_uploads_complete turnover branch is currently a two-file stub", {
+  # Commit 2 will fold in uploaded ratios / metadata; for now it mirrors the
+  # default rule and ignores has_turnover.
+  expect_true(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, TRUE, TRUE, TRUE))
+  expect_true(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, TRUE, TRUE, FALSE))
+  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, TRUE, FALSE, TRUE))
+  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, FALSE, TRUE, TRUE))
+})

--- a/tests/testthat/test-qc-data-upload.R
+++ b/tests/testthat/test-qc-data-upload.R
@@ -28,7 +28,7 @@ test_that("qc_required_protein_columns matches the summarization output keys", {
     MSstatsShiny:::qc_required_protein_columns(TEMPLATES$chemoproteomics),
     c("Protein", "GROUP", "RUN", "LogIntensities")
   )
-  # Turnover adds the heavy/light channel column (consumed in commit 2).
+  # Turnover adds the heavy/light channel column.
   expect_equal(
     MSstatsShiny:::qc_required_protein_columns(TEMPLATES$protein_turnover),
     c("Protein", "GROUP", "RUN", "LogIntensities", "LABEL")
@@ -48,34 +48,42 @@ test_that("qc_required_feature_columns is the MSstats feature-level key set", {
   expect_equal(MSstatsShiny:::qc_required_feature_columns(NULL), expected)
 })
 
-test_that("qc_uploads_complete needs both feature and protein tables (default/chemo)", {
-  expect_true(MSstatsShiny:::qc_uploads_complete(TEMPLATES$default, TRUE, TRUE, FALSE))
-  expect_true(MSstatsShiny:::qc_uploads_complete(TEMPLATES$chemoproteomics, TRUE, TRUE, FALSE))
+test_that("qc_uploads_complete needs both feature and protein tables (default)", {
+  # Default template ignores the mapping-validity flag.
+  expect_true(MSstatsShiny:::qc_uploads_complete(TEMPLATES$default, TRUE, TRUE, FALSE, FALSE))
 
   # Any single missing file leaves the upload incomplete.
-  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$default, TRUE, FALSE, FALSE))
-  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$default, FALSE, TRUE, FALSE))
-  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$default, FALSE, FALSE, FALSE))
-  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$chemoproteomics, FALSE, TRUE, FALSE))
+  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$default, TRUE, FALSE, FALSE, FALSE))
+  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$default, FALSE, TRUE, FALSE, FALSE))
+  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$default, FALSE, FALSE, FALSE, FALSE))
 })
 
-test_that("qc_uploads_complete turnover needs protein + ratios (feature optional)", {
-  # Turnover consumes the uploaded ratios table directly; FeatureLevelData is not
-  # used on the response-curve path, so protein + ratios is sufficient.
-  expect_true(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, FALSE, TRUE, TRUE))
-  expect_true(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, TRUE, TRUE, TRUE))
+test_that("qc_uploads_complete chemo needs feature + protein + valid mapping", {
+  expect_true(MSstatsShiny:::qc_uploads_complete(TEMPLATES$chemoproteomics, TRUE, TRUE, FALSE, TRUE))
 
-  # Missing ratios or protein leaves it incomplete; feature alone is not enough.
-  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, TRUE, TRUE, FALSE))
-  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, TRUE, FALSE, TRUE))
-  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, TRUE, FALSE, FALSE))
+  # Without a valid mapping the chemo upload is not ready, even with both files.
+  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$chemoproteomics, TRUE, TRUE, FALSE, FALSE))
+  # A missing file is still incomplete regardless of mapping.
+  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$chemoproteomics, FALSE, TRUE, FALSE, TRUE))
+})
+
+test_that("qc_uploads_complete turnover needs protein + ratios + mapping (feature optional)", {
+  # Turnover consumes the uploaded ratios table directly; FeatureLevelData is not
+  # used on the response-curve path, so protein + ratios + a valid mapping suffice.
+  expect_true(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, FALSE, TRUE, TRUE, TRUE))
+  expect_true(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, TRUE, TRUE, TRUE, TRUE))
+
+  # Missing ratios, protein, or mapping leaves it incomplete.
+  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, TRUE, TRUE, TRUE, FALSE))
+  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, TRUE, TRUE, FALSE, TRUE))
+  expect_false(MSstatsShiny:::qc_uploads_complete(TEMPLATES$protein_turnover, TRUE, FALSE, TRUE, TRUE))
 })
 
 test_that("qc_required_mapping_columns is template-specific", {
   expect_equal(MSstatsShiny:::qc_required_mapping_columns(TEMPLATES$protein_turnover),
                c("GROUP", "TimeVal"))
   expect_equal(MSstatsShiny:::qc_required_mapping_columns(TEMPLATES$chemoproteomics),
-               c("GROUP", "DoseVal"))
+               c("GROUP", "DoseVal", "DoseUnit", "DrugName"))
   expect_equal(MSstatsShiny:::qc_required_mapping_columns(TEMPLATES$default), character(0))
   expect_equal(MSstatsShiny:::qc_required_mapping_columns(NULL), character(0))
 })
@@ -109,4 +117,59 @@ test_that("qc_mapping_to_condition_metadata keeps optional chemo columns when pr
   out_full = MSstatsShiny:::qc_mapping_to_condition_metadata(full, TEMPLATES$chemoproteomics)
   expect_equal(colnames(out_full), c("Condition", "DoseVal", "DoseUnit", "DrugName"))
   expect_type(out_full$DrugName, "character")
+})
+
+test_that("qc_dose_units_valid accepts known units case-insensitively", {
+  expect_true(MSstatsShiny:::qc_dose_units_valid(c("nM", "uM", "mM", "M")))
+  expect_true(MSstatsShiny:::qc_dose_units_valid(c("nm", "UM", " mm ", "m")))
+
+  # Unknown, blank, or NA units are rejected.
+  expect_false(MSstatsShiny:::qc_dose_units_valid(c("nM", "ng")))
+  expect_false(MSstatsShiny:::qc_dose_units_valid(c("nM", "")))
+  expect_false(MSstatsShiny:::qc_dose_units_valid(c("nM", NA)))
+  expect_false(MSstatsShiny:::qc_dose_units_valid(character(0)))
+  expect_false(MSstatsShiny:::qc_dose_units_valid(NULL))
+})
+
+test_that("qc_mapping_group_errors flags unknown, missing, and duplicate groups", {
+  protein_groups = c("DMSO", "D1", "D2")
+
+  # Exact one-to-one mapping -> no errors.
+  expect_equal(
+    MSstatsShiny:::qc_mapping_group_errors(c("DMSO", "D1", "D2"), protein_groups),
+    character(0)
+  )
+  # Unknown mapping group.
+  unknown = MSstatsShiny:::qc_mapping_group_errors(c("DMSO", "D1", "D2", "D9"), protein_groups)
+  expect_length(unknown, 1)
+  expect_match(unknown, "not found in ProteinLevelData")
+  # Missing ProteinLevelData group.
+  missing = MSstatsShiny:::qc_mapping_group_errors(c("DMSO", "D1"), protein_groups)
+  expect_length(missing, 1)
+  expect_match(missing, "missing")
+  # Duplicate mapping rows.
+  dup = MSstatsShiny:::qc_mapping_group_errors(c("DMSO", "D1", "D1", "D2"), protein_groups)
+  expect_length(dup, 1)
+  expect_match(dup, "duplicate")
+})
+
+test_that("qc_values_numeric_finite requires numeric, finite values in all columns", {
+  ok = data.frame(TimeVal = c(0, 1, 2), H_frac = c(0.1, 0.2, 0.3),
+                  L_frac = c(0.9, 0.8, 0.7), stringsAsFactors = FALSE)
+  expect_true(MSstatsShiny:::qc_values_numeric_finite(ok, c("TimeVal", "H_frac", "L_frac")))
+
+  # Non-numeric value.
+  bad_char = ok
+  bad_char$H_frac = c("a", "0.2", "0.3")
+  expect_false(MSstatsShiny:::qc_values_numeric_finite(bad_char, c("TimeVal", "H_frac", "L_frac")))
+  # Non-finite value.
+  bad_inf = ok
+  bad_inf$L_frac = c(0.9, Inf, 0.7)
+  expect_false(MSstatsShiny:::qc_values_numeric_finite(bad_inf, c("TimeVal", "H_frac", "L_frac")))
+  # NA value.
+  bad_na = ok
+  bad_na$TimeVal = c(0, NA, 2)
+  expect_false(MSstatsShiny:::qc_values_numeric_finite(bad_na, c("TimeVal", "H_frac", "L_frac")))
+  # Absent column.
+  expect_false(MSstatsShiny:::qc_values_numeric_finite(ok, c("TimeVal", "Missing")))
 })

--- a/tests/testthat/test-qc-server-rendering.R
+++ b/tests/testthat/test-qc-server-rendering.R
@@ -104,6 +104,26 @@ test_that("qc_show_profileplot_options and qc_show_qualitymetrics_options key of
   expect_false(MSstatsShiny:::qc_show_qualitymetrics_options(NULL))
 })
 
+test_that("qc_has_feature_level detects usable feature-level data", {
+  # Present with rows (normal run / default + chemo upload) -> TRUE.
+  ok = list(FeatureLevelData = data.frame(ABUNDANCE = c(1, 2, 3)),
+            ProteinLevelData = data.frame(Protein = "P1"))
+  expect_true(MSstatsShiny:::qc_has_feature_level(ok))
+
+  # Protein-turnover upload shape: only ProteinLevelData -> FALSE.
+  turnover = list(FeatureLevelData = NULL,
+                  ProteinLevelData = data.frame(Protein = "P1"))
+  expect_false(MSstatsShiny:::qc_has_feature_level(turnover))
+
+  # Zero-row feature data -> FALSE.
+  empty = list(FeatureLevelData = data.frame(ABUNDANCE = numeric(0)),
+               ProteinLevelData = data.frame(Protein = "P1"))
+  expect_false(MSstatsShiny:::qc_has_feature_level(empty))
+
+  # NULL data object -> FALSE, no error.
+  expect_false(MSstatsShiny:::qc_has_feature_level(NULL))
+})
+
 test_that("download panels are complementary on the PTM biological question", {
   expect_true(MSstatsShiny:::qc_show_nonptm_downloads("Protein"))
   expect_true(MSstatsShiny:::qc_show_nonptm_downloads("Peptide"))

--- a/tests/testthat/test-qc-server-rendering.R
+++ b/tests/testthat/test-qc-server-rendering.R
@@ -104,26 +104,6 @@ test_that("qc_show_profileplot_options and qc_show_qualitymetrics_options key of
   expect_false(MSstatsShiny:::qc_show_qualitymetrics_options(NULL))
 })
 
-test_that("qc_has_feature_level detects usable feature-level data", {
-  # Present with rows (normal run / default + chemo upload) -> TRUE.
-  ok = list(FeatureLevelData = data.frame(ABUNDANCE = c(1, 2, 3)),
-            ProteinLevelData = data.frame(Protein = "P1"))
-  expect_true(MSstatsShiny:::qc_has_feature_level(ok))
-
-  # Protein-turnover upload shape: only ProteinLevelData -> FALSE.
-  turnover = list(FeatureLevelData = NULL,
-                  ProteinLevelData = data.frame(Protein = "P1"))
-  expect_false(MSstatsShiny:::qc_has_feature_level(turnover))
-
-  # Zero-row feature data -> FALSE.
-  empty = list(FeatureLevelData = data.frame(ABUNDANCE = numeric(0)),
-               ProteinLevelData = data.frame(Protein = "P1"))
-  expect_false(MSstatsShiny:::qc_has_feature_level(empty))
-
-  # NULL data object -> FALSE, no error.
-  expect_false(MSstatsShiny:::qc_has_feature_level(NULL))
-})
-
 test_that("download panels are complementary on the PTM biological question", {
   expect_true(MSstatsShiny:::qc_show_nonptm_downloads("Protein"))
   expect_true(MSstatsShiny:::qc_show_nonptm_downloads("Peptide"))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Motivation and Context
The QC workflow previously assumed users would run the built-in preprocessing pipeline; there was no supported path to drive the QC page from **already pre-processed** data. This change adds a template-aware **“Data Upload”** tab so users can upload validated, case-sensitive CSVs for `FeatureLevelData` and `ProteinLevelData` (plus optional template-specific mapping and, for the turnover template, turnover ratios). QC server routing and the “Next step” flow are updated so the app uses these **uploaded effective preprocess outputs** when load-page data is absent, while also hardening several template/comparison conditional branches against `NULL`/`NA`.

## Changes
- **QC UI: new Data Upload tab**
  - Added a **“Data Upload”** tab in `R/module-qc-ui.R` with an “Upload pre-processed data” panel.
  - Implemented required, **case-sensitive** column validation and display for:
    - `FeatureLevelData`
    - `ProteinLevelData`
  - Added **template-gated** (server-side hidden until enabled) extra upload panels:
    - **Mapping** CSV uploader (`GROUP` → time/dose mapping) with required columns that differ by template (protein turnover vs chemoproteomics).
    - **Turnover Ratios** CSV uploader (turnover template only), including a note that `FeatureLevelData` is not required for turnover analysis.
  - Wired template-gated panel visibility via constants added to `R/constants.R`:
    - `data_upload_mapping_panel`
    - `data_upload_ratios_panel`

- **QC server: integrate “effective uploaded” data into the QC flow**
  - Updated `qcServer` in `R/module-qc-server.R`:
    - Registers turnover ratios earlier via `register_qc_turnover(...)`.
    - Registers the new data-upload component via `register_qc_data_upload(...)` that consumes:
      - existing `preprocess_data`
      - `get_condition_metadata`
      - the previously registered turnover ratios
    - Rewired “Next step” UI behavior to trigger from upload-derived readiness:
      - `cap` reactive and `output$submit.button` rendering now depend on `data_upload$effective_preprocess_data()`
      - button wiring uses `ignoreNULL = TRUE` to prevent firing when effective preprocess data is not yet available
    - Updated the caption/button guidance text to the new upload-driven readiness message (“Data is ready. Click 'Next step'…”).
    - Updated module return values so:
      - `preprocessData` comes from `data_upload$effective_preprocess_data`
      - `turnoverRatios` comes from `data_upload$effective_turnover_ratios`
      - instead of returning the original `preprocess_data`/registered `turnover_ratios` directly.

- **New QC upload module implementation**
  - Added `R/qc-server-data-upload.R` implementing `register_qc_data_upload(...)`:
    - Uploads supported:
      - `FeatureLevelData` CSV
      - `ProteinLevelData` CSV
      - optional mapping CSV (`GROUP` → time/dose mapping; template-specific required columns)
      - optional turnover ratios CSV (turnover template only)
    - Helper functions introduced for required-column declarations, missing-column computation, completeness checks, and mapping translation:
      - required protein/feature/mapping/ratios column sets
      - `qc_missing_upload_columns(...)`
      - `qc_uploads_complete(...)`
      - `qc_mapping_to_condition_metadata(...)`
    - Parsing/validation behavior:
      - Parses CSVs via `data.table::fread`
      - Notifies users on read/validation failures
      - Resets invalid reactive state to `NULL`
      - Coerces uploaded `GROUP` values to a factor
      - Validates mapping CSV:
        - required columns exist
        - template-specific value column (`TimeVal` or `DoseVal`) is numeric-coercible
        - uploaded `GROUP` values match the `GROUP` levels present in the uploaded `ProteinLevelData`
      - Converts validated mapping into downstream `condition_metadata` format (via injected `get_condition_metadata` setter when available)
    - “Effective” routing reactives:
      - `effective_preprocess_data`: uses uploaded Feature/Protein data only when load-page data is `NULL` and uploads are complete; otherwise delegates to existing `preprocess_data()`.
      - `effective_turnover_ratios`: uses uploaded turnover ratios when load-page data is absent; otherwise delegates to existing `turnover_ratios()`.
    - UI visibility logic:
      - Upload tab is shown only until load-page data exists; if load-page data exists, the UI switches/hides accordingly.
      - Summarization “run” UI state is toggled based on whether the two main uploads are unset/complete.
      - Mapping/ratios upload panels are template-gated using `shinyjs::toggle`.

- **Additional NULL/NA hardening and robustness**
  - Updated template/comparison branching logic to be `NULL`/`NA` safe using `isTRUE(...)` checks:
    - `R/statmodel-server-comparisons.R` (condition selection logic)
    - `R/statmodel-server-download-code.R` (model branching and `dt` selection wiring)
    - `R/utils.R` (`preprocessData`, `preprocessDataCode`, and `dataComparison` routing)
  - Updated `render_group_comparison_plot_inputs` to accept additional context and be resilient to missing protein-name sources:
    - `R/statmodel-server-visualization.R`
    - Adds a `preprocess_data` reactive argument (defaults to `reactive(NULL)`)
    - Falls back to extracting protein names from `preprocess_data()` if `get_data()` is missing/empty, with error handling
    - Avoids rendering a protein `selectInput` when no proteins can be derived
  - Updated `R/statmodel-server-comparisons.R` to pass `preprocess_data` into `render_group_comparison_plot_inputs`.

## Unit Tests
- Added `tests/testthat/test-qc-data-upload.R` covering:
  - `qc_missing_upload_columns` missing detection with required-column **ordering** expectations while treating input as name-based.
  - Required-column set helpers:
    - `qc_required_protein_columns` across default/chemoproteomics/turnover templates (and fallback when template is `NULL`)
    - `qc_required_feature_columns` across templates (and for `NULL`)
  - Upload completeness logic via `qc_uploads_complete`:
    - default/chemoproteomics require both feature + protein
    - turnover completeness depends on protein + ratios (feature optional), including explicit true/false cases
  - Mapping/ratios helpers:
    - `qc_required_mapping_columns`
    - `qc_required_ratios_columns`
    - `qc_mapping_to_condition_metadata`, including turnover `GROUP` → `Condition` renaming and preservation of optional chemoproteomics columns only when provided.

## Coding Guidelines
- No coding guideline violations were indicated by the changes provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->