### PR TITLE
Add metabolomics support to the Network Interpretation tab

### DIFF
--- a/R/module-visualize-network-server.R
+++ b/R/module-visualize-network-server.R
@@ -277,14 +277,16 @@ export_network_html <- function(render_data, displayLabelType, file) {
 #' @param id Module ID string
 #' @param parent_session Parent Shiny session
 #' @param dataComparison Reactive expression containing comparison data
+#' @param app_template Reactive returning the selected template name (e.g. TEMPLATES$default)
 #'
 #' @return None (side effects only)
 #' 
 #' @importFrom MSstatsBioNet annotateProteinInfoFromIndra getSubnetworkFromIndra
 #' @importFrom DT renderDT datatable
-#' @importFrom shiny moduleServer updateSelectizeInput showNotification outputOptions
+#' @importFrom shiny moduleServer updateSelectizeInput showNotification outputOptions updateRadioButtons
 #' @importFrom httr POST content_type_json accept_json content status_code
-visualizeNetworkServer <- function(id, parent_session, dataComparison) {
+visualizeNetworkServer <- function(id, parent_session, dataComparison,
+                                   app_template = reactive(TEMPLATES$default)) {
   moduleServer(id, function(input, output, session) {
   
   # Output to control conditional panels
@@ -294,6 +296,71 @@ visualizeNetworkServer <- function(id, parent_session, dataComparison) {
       !is.null(extractComparisonResult(dataComparison)$Protein)
   })
   outputOptions(output, "hasValidDataComparison", suspendWhenHidden = FALSE)
+
+  is_metabolomics <- reactive(isTRUE(app_template() == TEMPLATES$metabolomics))
+
+  output$idTypeLabel <- renderUI({
+    if (is_metabolomics()) {
+      tags$label(
+        "Analyte ID Type:",
+        class = "icon-wrapper",
+        icon("question-circle", lib = "font-awesome"),
+        div("Select the type of analyte identifier used in your data. For metabolomics, analytes are grounded by name (e.g., glucose, citrate).",
+            class = "icon-tooltip")
+      )
+    } else {
+      tags$label(
+        "Protein ID Type:",
+        class = "icon-wrapper",
+        icon("question-circle", lib = "font-awesome"),
+        div("Select the type of protein identifier used in your data. Uniprot Mnemonic uses readable names (e.g., P53_HUMAN), while Uniprot uses alphanumeric codes (e.g., P04637).",
+            class = "icon-tooltip")
+      )
+    }
+  })
+
+  output$displayLabelHeader <- renderUI({
+    if (is_metabolomics()) {
+      tags$label(
+        "Node Label Display:",
+        class = "icon-wrapper",
+        icon("question-circle", lib = "font-awesome"),
+        div("Choose how metabolite nodes are labeled. Metabolite Name shows the identifier from your data; Grounded Name shows the standardized name resolved during annotation.",
+            class = "icon-tooltip")
+      )
+    } else {
+      tags$label(
+        "Node Label Display:",
+        class = "icon-wrapper",
+        icon("question-circle", lib = "font-awesome"),
+        div("Choose how protein nodes are labeled in the network visualization. Protein Name shows the full protein name, Gene Name shows the HGNC gene symbol.",
+            class = "icon-tooltip")
+      )
+    }
+  })
+
+  observeEvent(app_template(), {
+    if (is_metabolomics()) {
+      updateRadioButtons(session, "proteinIdType",
+                         choices = list("Metabolite" = "Metabolite"),
+                         selected = "Metabolite")
+      updateRadioButtons(session, "displayLabelType",
+                         choices = list("Metabolite Name" = "id",
+                                        "Grounded Name" = "entityName"),
+                         selected = "id")
+      shinyjs::hide("filter_by_ptm_site")
+    } else {
+      updateRadioButtons(session, "proteinIdType",
+                         choices = list("Uniprot Mnemonic" = "Uniprot_Mnemonic",
+                                        "Uniprot" = "Uniprot"),
+                         selected = "Uniprot")
+      updateRadioButtons(session, "displayLabelType",
+                         choices = list("Protein Name" = "id",
+                                        "Gene Name" = "entityName"),
+                         selected = "id")
+      shinyjs::show("filter_by_ptm_site")
+    }
+  }, ignoreInit = FALSE)
   
   # Reactive value to store selected proteins
   selectedProteinsReactive <- reactiveVal(character(0))
@@ -311,7 +378,7 @@ visualizeNetworkServer <- function(id, parent_session, dataComparison) {
   output$selectedProteinsTags <- renderUI({
     proteins <- selectedProteinsReactive()
     if (length(proteins) == 0) {
-      return(div(style = "color: #999; font-style: italic;", "No proteins selected"))
+      return(div(style = "color: #999; font-style: italic;", "No analytes selected"))
     }
     
     ns <- session$ns
@@ -344,7 +411,7 @@ visualizeNetworkServer <- function(id, parent_session, dataComparison) {
     }
     
     # Show loading notification
-    showNotification("Searching for protein...", type = "message", duration = 2)
+    showNotification("Searching for analyte...", type = "message", duration = 2)
     
     # Call INDRA grounding API
     tryCatch({
@@ -404,7 +471,7 @@ visualizeNetworkServer <- function(id, parent_session, dataComparison) {
         }
       } else {
         proteinSearchResults(NULL)
-        showNotification("Error searching protein database", type = "error", duration = 3)
+        showNotification("Error searching analyte database", type = "error", duration = 3)
       }
     }, error = function(e) {
       proteinSearchResults(NULL)
@@ -463,7 +530,7 @@ visualizeNetworkServer <- function(id, parent_session, dataComparison) {
       selectedProteinsReactive(c(current, identifier))
       showNotification(sprintf("Added: %s", selected), type = "message", duration = 2)
     } else {
-      showNotification("Protein already selected", type = "warning", duration = 2)
+      showNotification("Analyte already selected", type = "warning", duration = 2)
     }
     
     # Clear search
@@ -477,7 +544,7 @@ visualizeNetworkServer <- function(id, parent_session, dataComparison) {
     current <- selectedProteinsReactive()
     if (index > 0 && index <= length(current)) {
       selectedProteinsReactive(current[-index])
-      showNotification("Protein removed", type = "message", duration = 2)
+      showNotification("Analyte removed", type = "message", duration = 2)
     }
   })
   

--- a/R/module-visualize-network-ui.R
+++ b/R/module-visualize-network-ui.R
@@ -55,14 +55,8 @@ createLabelDropdown <- function(ns) {
 
 createProteinIdRadioButtons <- function(ns) {
   div(
-    tags$label(
-      "Protein ID Type:",
-      class = "icon-wrapper",
-      icon("question-circle", lib = "font-awesome"),
-      div("Select the type of protein identifier used in your data. Uniprot Mnemonic uses readable names (e.g., P53_HUMAN), while Uniprot uses alphanumeric codes (e.g., P04637).", 
-          class = "icon-tooltip")
-    ),
-    radioButtons(ns("proteinIdType"), 
+    uiOutput(ns("idTypeLabel")),
+    radioButtons(ns("proteinIdType"),
                  label = NULL,  # Remove since we're handling it above
                  choices = list("Uniprot Mnemonic" = "Uniprot_Mnemonic", 
                                 "Uniprot" = "Uniprot"),
@@ -72,17 +66,11 @@ createProteinIdRadioButtons <- function(ns) {
 
 createDisplayLabelRadioButtons <- function(ns) {
   div(
-    tags$label(
-      "Node Label Display:",
-      class = "icon-wrapper",
-      icon("question-circle", lib = "font-awesome"),
-      div("Choose how protein nodes are labeled in the network visualization. Protein Name shows the full protein name, Gene Name shows the HGNC gene symbol.", 
-          class = "icon-tooltip")
-    ),
+    uiOutput(ns("displayLabelHeader")),
     radioButtons(ns("displayLabelType"),
                  label = NULL,  # Remove since we're handling it above
                  choices = list("Protein Name" = "id",
-                                "Gene Name" = "hgncName"),
+                                "Gene Name" = "entityName"),
                  selected = "id")
   )
 }
@@ -94,7 +82,7 @@ createParameterSliders <- function(ns) {
         "Adjusted P-Value:",
         class = "icon-wrapper",
         icon("question-circle", lib = "font-awesome"),
-        div("Statistical significance threshold. Only proteins with adjusted p-values below this cutoff will be included in the network.", 
+        div("Statistical significance threshold. Only analytes with adjusted p-values below this cutoff will be included in the network.",
             class = "icon-tooltip")
       ),
       sliderInput(ns("pValue"), 
@@ -106,7 +94,7 @@ createParameterSliders <- function(ns) {
         "Absolute LogFC Cutoff:",
         class = "icon-wrapper",
         icon("question-circle", lib = "font-awesome"),
-        div("Minimum absolute log fold change value for including proteins. Higher values focus on more dramatically changed proteins.", 
+        div("Minimum absolute log fold change value for including analytes. Higher values focus on more dramatically changed analytes.",
             class = "icon-tooltip")
       ),
       sliderInput(ns("absLogFC"),
@@ -118,7 +106,7 @@ createParameterSliders <- function(ns) {
         "INDRA Evidence Cutoff:",
         class = "icon-wrapper",
         icon("question-circle", lib = "font-awesome"),
-        div("Minimum number of supporting evidence lines required for including a protein regulatory relationship. Each count reflects a separate line of support, such as a sentence in a paper or an entry in a curated database, not necessarily distinct publications. Higher values increase confidence but may reduce network size.", 
+        div("Minimum number of supporting evidence lines required for including a regulatory relationship. Each count reflects a separate line of support, such as a sentence in a paper or an entry in a curated database, not necessarily distinct publications. Higher values increase confidence but may reduce network size.", 
             class = "icon-tooltip")
       ),
       sliderInput(ns("evidence"), 
@@ -178,7 +166,7 @@ createFilterDropdowns <- function(ns) {
         "INDRA Sources:",
         class = "icon-wrapper",
         icon("question-circle", lib = "font-awesome"),
-        div("Filter regulatory relationships by data source. Different sources use various methods to identify protein regulatory relationships (literature mining, manual curation, etc.).", 
+        div("Filter regulatory relationships by data source. Different sources use various methods to identify regulatory relationships (literature mining, manual curation, etc.).", 
             class = "icon-tooltip")
       ),
       selectInput(ns("sources"),
@@ -221,10 +209,10 @@ createFilterDropdowns <- function(ns) {
     ),
     div(
       tags$label(
-        "Force Include Proteins (optional):",
+        "Force Include Analytes (optional):",
         class = "icon-wrapper",
         icon("question-circle", lib = "font-awesome"),
-        div("Search for specific proteins to include in the network analysis regardless of other filtering criteria. As a hidden feature, you can also search by any biological agent, e.g. drugs, GO terms, etc!", 
+        div("Search for specific analytes to include in the network analysis regardless of other filtering criteria. As a hidden feature, you can also search by any biological agent, e.g. drugs, GO terms, etc!",
             class = "icon-tooltip")
       ),
       # Container for selected proteins
@@ -237,7 +225,7 @@ createFilterDropdowns <- function(ns) {
         style = "display: flex; gap: 10px; align-items: flex-start;",
         textInput(ns("proteinSearchInput"),
                   label = NULL,
-                  placeholder = "Type protein name or gene symbol...",
+                  placeholder = "Type analyte name or identifier...",
                   width = "70%"),
         actionButton(ns("proteinSearchButton"),
                      "Search",
@@ -273,7 +261,7 @@ createAdvancedOptionsCollapsible <- function(ns) {
                           "Filter out statements curated as incorrect",
                           class = "icon-wrapper",
                           icon("question-circle", lib = "font-awesome"),
-                          div("When checked, excludes protein regulatory relationships that have been manually curated as incorrect in the INDRA database.", 
+                          div("When checked, excludes regulatory relationships that have been manually curated as incorrect in the INDRA database.",
                               class = "icon-tooltip")
                         ), 
                         value = FALSE),
@@ -291,7 +279,7 @@ createAdvancedOptionsCollapsible <- function(ns) {
                           "Include infinite fold change",
                           class = "icon-wrapper",
                           icon("question-circle", lib = "font-awesome"),
-                          div("Enable to include proteins/PTMs with infinite log fold change (i.e. proteins that are only detected in one condition).", 
+                          div("Enable to include analytes with infinite log fold change (i.e. analytes that are only detected in one condition).",
                               class = "icon-tooltip")
                         ), 
                         value = FALSE),
@@ -300,9 +288,9 @@ createAdvancedOptionsCollapsible <- function(ns) {
                         "Direction of regulation",
                         class = "icon-wrapper",
                         icon("question-circle", lib = "font-awesome"),
-                        div("Specify the direction of regulation of differentially abundant proteins/PTMs to include in the network. 
-                            'Upregulated only' only includes up-regulated proteins/PTMs (positive log fold change), 
-                            while 'Downregulated only' only includes down-regulated proteins/PTMs (negative log fold change).", 
+                        div("Specify the direction of regulation of differentially abundant analytes to include in the network.
+                            'Upregulated only' only includes up-regulated analytes (positive log fold change),
+                            while 'Downregulated only' only includes down-regulated analytes (negative log fold change).",
                             class = "icon-tooltip")
                       ), 
                       choices = c(
@@ -403,7 +391,7 @@ createNetworkSettingsTab <- function(ns) {
            div(
              style = "text-align: center; width: 100%;",
              p(
-               "Explore your differential abundance analysis results with respect to what is known in prior literature in the form of protein regulatory networks. If your differential abundance analysis results were not obtained through MSstatsShiny, you can upload your differential abundance analysis results as a CSV file.",
+               "Explore your differential abundance analysis results with respect to what is known in prior literature in the form of regulatory networks. If your differential abundance analysis results were not obtained through MSstatsShiny, you can upload your differential abundance analysis results as a CSV file.",
                style = "margin: 0;"
              )
            ),

--- a/R/server.R
+++ b/R/server.R
@@ -79,7 +79,7 @@ server = function(input, output, session) {
   })
   
   # visualizeNetworkServer - keep callModule if not yet refactored
-  visualizeNetworkServer("network", parent_session = session, dataComparison = data_comparison)
+  visualizeNetworkServer("network", parent_session = session, dataComparison = data_comparison, app_template = app_template)
   
   observe({
     if(input$"loadpage-DDA_DIA" %in% c("TMT") && input$"loadpage-BIO" %in% c("PTM")) {


### PR DESCRIPTION
Add metabolomics support to the Network Interpretation tab (Metabolite ID type, analyte-agnostic wording, PTM controls gated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and context

The Network Interpretation tab was protein/PTM-specific, limiting its use for metabolomics data. This change generalizes the interface to analytes, adds metabolite ID support, and hides PTM-only controls when working with metabolomics templates.

## Changes

- Added `app_template` as a reactive parameter to `visualizeNetworkServer()`.
- Passed the selected application template from `server.R` into the visualization module.
- Added template-aware behavior for:
  - Metabolite versus protein/analyte ID types.
  - Node-label guidance.
  - PTM filter visibility.
  - Label and ID radio-button selections.
- Generalized UI labels, tooltips, instructions, and notifications from protein-specific to analyte-oriented wording.
- Updated the gene-name display value from `hgncName` to `entityName`.
- Renamed the force-include control and analyte search placeholder.
- Generalized network settings text from protein regulatory networks to regulatory networks.

## Tests

No unit tests were added or modified.

## Coding guideline violations

No coding guideline violations were identified from the provided changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->